### PR TITLE
Add terrain mesh generation for elevation editing

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -16,7 +16,7 @@ fn spawn_camera(mut commands: Commands) {
     commands.spawn(Camera3dBundle {
         transform,
         projection: Projection::Orthographic(OrthographicProjection {
-            scale: 0.1, // tweak zoom
+            scale: 0.03, // tweak zoom
             ..default()
         }),
         ..default()

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,13 +1,22 @@
+use crate::terrain;
+use crate::types::*;
 use bevy::prelude::*;
 use bevy_egui::EguiContexts;
-use crate::types::*;
 
 pub struct EditorPlugin;
 impl Plugin for EditorPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<EditorState>()
-            .add_systems(Startup, spawn_grid_materials)
-            .add_systems(Update, (update_hover, paint_tiles, draw_hover_highlight));
+            .add_systems(Startup, spawn_editor_assets)
+            .add_systems(
+                Update,
+                (
+                    update_hover,
+                    paint_tiles,
+                    rebuild_terrain_mesh,
+                    draw_hover_highlight,
+                ),
+            );
     }
 }
 
@@ -15,29 +24,63 @@ impl Plugin for EditorPlugin {
 pub struct EditorState {
     pub current_kind: TileKind,
     pub current_elev: i8, // -1..3
-    pub hover: Option<(u32,u32)>,
+    pub hover: Option<(u32, u32)>,
     pub map: TileMap,
+    pub map_dirty: bool,
 }
 impl Default for EditorState {
     fn default() -> Self {
-        Self { current_kind: TileKind::Floor, current_elev: 0, hover: None, map: TileMap::new(64,64) }
+        Self {
+            current_kind: TileKind::Floor,
+            current_elev: 0,
+            hover: None,
+            map: TileMap::new(64, 64),
+            map_dirty: true,
+        }
     }
 }
 
 // Simple green overlay material
 #[derive(Resource)]
-struct Materials { hover: Handle<StandardMaterial> }
+struct Materials {
+    hover: Handle<StandardMaterial>,
+}
 
-fn spawn_grid_materials(
+#[derive(Resource)]
+struct TerrainVisual {
+    mesh: Handle<Mesh>,
+}
+
+fn spawn_editor_assets(
     mut commands: Commands,
     mut mats: ResMut<Assets<StandardMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
 ) {
     let hover = mats.add(StandardMaterial {
         base_color: Color::rgba(0.0, 1.0, 0.0, 0.25),
         unlit: true,
         ..default()
     });
+    let terrain_material = mats.add(StandardMaterial {
+        base_color: Color::rgb(0.35, 0.55, 0.2),
+        perceptual_roughness: 0.8,
+        metallic: 0.0,
+        ..default()
+    });
+
+    let terrain_mesh = meshes.add(Mesh::new(
+        bevy::render::render_resource::PrimitiveTopology::TriangleList,
+    ));
+
+    commands.spawn(PbrBundle {
+        mesh: terrain_mesh.clone(),
+        material: terrain_material.clone(),
+        transform: Transform::default(),
+        ..default()
+    });
+
     commands.insert_resource(Materials { hover });
+    commands.insert_resource(TerrainVisual { mesh: terrain_mesh });
 }
 
 // Raycast to ground plane at chosen elevation (use current_elev for edit layer)
@@ -46,12 +89,18 @@ fn update_hover(
     windows: Query<&Window>,
     cameras: Query<(&Camera, &GlobalTransform)>,
     mut egui: EguiContexts,
-){
+) {
     let (cam, cam_xform) = cameras.single();
     let win = windows.single();
 
-    if egui.ctx_mut().wants_pointer_input() { state.hover = None; return; }
-    let Some(cursor) = win.cursor_position() else { state.hover = None; return; };
+    if egui.ctx_mut().wants_pointer_input() {
+        state.hover = None;
+        return;
+    }
+    let Some(cursor) = win.cursor_position() else {
+        state.hover = None;
+        return;
+    };
 
     if let Some(ray) = cam.viewport_to_world(cam_xform, cursor) {
         let plane_y = state.current_elev as f32 * TILE_HEIGHT;
@@ -60,7 +109,7 @@ fn update_hover(
             let hit = ray.origin + ray.direction * t;
             let x = (hit.x / TILE_SIZE).floor() as i32;
             let y = (hit.z / TILE_SIZE).floor() as i32;
-            if x>=0 && y>=0 && (x as u32) < state.map.width && (y as u32) < state.map.height {
+            if x >= 0 && y >= 0 && (x as u32) < state.map.width && (y as u32) < state.map.height {
                 state.hover = Some((x as u32, y as u32));
                 return;
             }
@@ -73,21 +122,54 @@ fn paint_tiles(
     buttons: Res<ButtonInput<MouseButton>>,
     mut state: ResMut<EditorState>,
     mut egui: EguiContexts,
-){
-    if egui.ctx_mut().wants_pointer_input() { return; }
+) {
+    if egui.ctx_mut().wants_pointer_input() {
+        return;
+    }
     if buttons.pressed(MouseButton::Left) {
-        if let Some((x,y)) = state.hover {
+        if let Some((x, y)) = state.hover {
             let kind = state.current_kind;
             let elevation = state.current_elev;
-            let state = &mut state;
-            
-            state.map.set(x,y, Tile { kind, elevation, tile_type: TileType::Grass, x, y });
+            let state_ref = &mut *state;
+            let current = state_ref.map.get(x, y);
+            if current.kind != kind || current.elevation != elevation {
+                let tile_type = current.tile_type.clone();
+                state_ref.map.set(
+                    x,
+                    y,
+                    Tile {
+                        kind,
+                        elevation,
+                        tile_type,
+                        x,
+                        y,
+                    },
+                );
+                state_ref.map_dirty = true;
+            }
         }
     }
 }
 
+fn rebuild_terrain_mesh(
+    mut state: ResMut<EditorState>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    visual: Res<TerrainVisual>,
+) {
+    if !state.map_dirty {
+        return;
+    }
+    state.map_dirty = false;
+
+    let mesh = terrain::build_map_mesh(&state.map);
+    if let Some(existing) = meshes.get_mut(&visual.mesh) {
+        *existing = mesh;
+    }
+}
+
 // Draw a thin quad on hovered tile at its elevation
-#[derive(Component)] struct HoverMarker;
+#[derive(Component)]
+struct HoverMarker;
 
 fn draw_hover_highlight(
     mut commands: Commands,
@@ -95,20 +177,29 @@ fn draw_hover_highlight(
     mats: Res<Materials>,
     state: Res<EditorState>,
     existing: Query<Entity, With<HoverMarker>>,
-){
+) {
     // clear previous
-    for e in &existing { commands.entity(e).despawn(); }
+    for e in &existing {
+        commands.entity(e).despawn();
+    }
 
-    if let Some((x,y)) = state.hover {
-        let min = Vec3::new(x as f32 * TILE_SIZE, state.current_elev as f32 * TILE_HEIGHT + 0.01, y as f32 * TILE_SIZE);
+    if let Some((x, y)) = state.hover {
+        let min = Vec3::new(
+            x as f32 * TILE_SIZE,
+            state.current_elev as f32 * TILE_HEIGHT + 0.01,
+            y as f32 * TILE_SIZE,
+        );
         let size = Vec2::splat(TILE_SIZE);
         let mesh = Mesh::from(Rectangle::new(size.x, size.y));
         commands.spawn((
             PbrBundle {
                 mesh: meshes.add(mesh),
                 material: mats.hover.clone(),
-                transform: Transform::from_translation(min + Vec3::new(TILE_SIZE*0.5,0.0,TILE_SIZE*0.5))
-                    * Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
+                transform: Transform::from_translation(
+                    min + Vec3::new(TILE_SIZE * 0.5, 0.0, TILE_SIZE * 0.5),
+                ) * Transform::from_rotation(Quat::from_rotation_x(
+                    -std::f32::consts::FRAC_PI_2,
+                )),
                 ..default()
             },
             HoverMarker,

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,6 +1,7 @@
 use crate::terrain;
 use crate::types::*;
 use bevy::prelude::*;
+use bevy::render::render_asset::RenderAssetUsages;
 use bevy_egui::EguiContexts;
 
 pub struct EditorPlugin;
@@ -70,6 +71,7 @@ fn spawn_editor_assets(
 
     let terrain_mesh = meshes.add(Mesh::new(
         bevy::render::render_resource::PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
     ));
 
     commands.spawn(PbrBundle {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
+mod camera;
 mod controls;
 mod editor;
+mod grid_visual;
 mod io;
+mod terrain;
 mod types;
 mod ui;
-mod camera;
-mod grid_visual;
-
 
 use bevy::prelude::*;
 use bevy_egui::EguiPlugin;
@@ -20,13 +20,16 @@ fn main() {
         .add_plugins((CameraPlugin, ControlsPlugin, EditorPlugin, UiPlugin))
         .add_systems(Startup, setup_light)
         .add_systems(Update, grid_visual::draw_grid)
-
         .run();
 }
 
 fn setup_light(mut commands: Commands) {
     commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight { illuminance: 20_000.0, shadows_enabled: false, ..default() },
+        directional_light: DirectionalLight {
+            illuminance: 20_000.0,
+            shadows_enabled: false,
+            ..default()
+        },
         transform: Transform::from_rotation(Quat::from_euler(EulerRot::XYZ, -1.2, -0.8, 0.0)),
         ..default()
     });

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -1,0 +1,290 @@
+use crate::types::{TILE_HEIGHT, TILE_SIZE, TileKind, TileMap};
+use bevy::prelude::*;
+use bevy::render::mesh::Indices;
+
+enum Direction {
+    North,
+    East,
+    South,
+    West,
+}
+
+const CORNER_NW: usize = 0;
+const CORNER_NE: usize = 1;
+const CORNER_SW: usize = 2;
+const CORNER_SE: usize = 3;
+
+pub fn build_map_mesh(map: &TileMap) -> Mesh {
+    if map.width == 0 || map.height == 0 {
+        return Mesh::new(bevy::render::render_resource::PrimitiveTopology::TriangleList);
+    }
+
+    // Cache corner heights for every tile so we can stitch seams reliably.
+    let mut corner_cache = vec![[0.0f32; 4]; (map.width * map.height) as usize];
+    for y in 0..map.height {
+        for x in 0..map.width {
+            let idx = map.idx(x, y);
+            let tile = map.get(x, y);
+            let base = tile.elevation as f32 * TILE_HEIGHT;
+            let mut corners = [base; 4];
+
+            if tile.kind == TileKind::Ramp {
+                if let Some((dir, neighbor_height)) = find_ramp_target(map, x, y, base) {
+                    match dir {
+                        Direction::North => {
+                            corners[CORNER_NW] = neighbor_height;
+                            corners[CORNER_NE] = neighbor_height;
+                        }
+                        Direction::South => {
+                            corners[CORNER_SW] = neighbor_height;
+                            corners[CORNER_SE] = neighbor_height;
+                        }
+                        Direction::West => {
+                            corners[CORNER_NW] = neighbor_height;
+                            corners[CORNER_SW] = neighbor_height;
+                        }
+                        Direction::East => {
+                            corners[CORNER_NE] = neighbor_height;
+                            corners[CORNER_SE] = neighbor_height;
+                        }
+                    }
+                }
+            }
+
+            corner_cache[idx] = corners;
+        }
+    }
+
+    let mut positions = Vec::new();
+    let mut normals = Vec::new();
+    let mut uvs = Vec::new();
+    let mut indices = Vec::new();
+    let mut next_index: u32 = 0;
+
+    for y in 0..map.height {
+        for x in 0..map.width {
+            let idx = map.idx(x, y);
+            let corners = corner_cache[idx];
+            let x0 = x as f32 * TILE_SIZE;
+            let x1 = x0 + TILE_SIZE;
+            let z0 = y as f32 * TILE_SIZE;
+            let z1 = z0 + TILE_SIZE;
+
+            let nw = Vec3::new(x0, corners[CORNER_NW], z0);
+            let ne = Vec3::new(x1, corners[CORNER_NE], z0);
+            let sw = Vec3::new(x0, corners[CORNER_SW], z1);
+            let se = Vec3::new(x1, corners[CORNER_SE], z1);
+
+            push_quad(
+                &mut positions,
+                &mut normals,
+                &mut uvs,
+                &mut indices,
+                &mut next_index,
+                [nw, sw, se, ne],
+                [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]],
+            );
+
+            // North edge (towards y-1)
+            let (bnw, bne) = if y > 0 {
+                let neighbor = corner_cache[map.idx(x, y - 1)];
+                (neighbor[CORNER_SW], neighbor[CORNER_SE])
+            } else {
+                (0.0, 0.0)
+            };
+            add_side_face(
+                &mut positions,
+                &mut normals,
+                &mut uvs,
+                &mut indices,
+                &mut next_index,
+                nw,
+                ne,
+                Vec3::new(x0, bnw.min(nw.y), z0),
+                Vec3::new(x1, bne.min(ne.y), z0),
+                Direction::North,
+            );
+
+            // South edge (towards y+1)
+            let (bsw, bse) = if y + 1 < map.height {
+                let neighbor = corner_cache[map.idx(x, y + 1)];
+                (neighbor[CORNER_NW], neighbor[CORNER_NE])
+            } else {
+                (0.0, 0.0)
+            };
+            add_side_face(
+                &mut positions,
+                &mut normals,
+                &mut uvs,
+                &mut indices,
+                &mut next_index,
+                se,
+                sw,
+                Vec3::new(x1, bse.min(se.y), z1),
+                Vec3::new(x0, bsw.min(sw.y), z1),
+                Direction::South,
+            );
+
+            // West edge (towards x-1)
+            let (bnw, bsw) = if x > 0 {
+                let neighbor = corner_cache[map.idx(x - 1, y)];
+                (neighbor[CORNER_NE], neighbor[CORNER_SE])
+            } else {
+                (0.0, 0.0)
+            };
+            add_side_face(
+                &mut positions,
+                &mut normals,
+                &mut uvs,
+                &mut indices,
+                &mut next_index,
+                sw,
+                nw,
+                Vec3::new(x0, bsw.min(sw.y), z1),
+                Vec3::new(x0, bnw.min(nw.y), z0),
+                Direction::West,
+            );
+
+            // East edge (towards x+1)
+            let (bne, bse) = if x + 1 < map.width {
+                let neighbor = corner_cache[map.idx(x + 1, y)];
+                (neighbor[CORNER_NW], neighbor[CORNER_SW])
+            } else {
+                (0.0, 0.0)
+            };
+            add_side_face(
+                &mut positions,
+                &mut normals,
+                &mut uvs,
+                &mut indices,
+                &mut next_index,
+                ne,
+                se,
+                Vec3::new(x1, bne.min(ne.y), z0),
+                Vec3::new(x1, bse.min(se.y), z1),
+                Direction::East,
+            );
+        }
+    }
+
+    let mut mesh = Mesh::new(bevy::render::render_resource::PrimitiveTopology::TriangleList);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+    mesh.insert_indices(Indices::U32(indices));
+    mesh
+}
+
+fn find_ramp_target(map: &TileMap, x: u32, y: u32, base: f32) -> Option<(Direction, f32)> {
+    let mut result: Option<(Direction, f32)> = None;
+    let mut consider = |dir: Direction, nx: i32, ny: i32| {
+        if nx < 0 || ny < 0 {
+            return;
+        }
+        let (ux, uy) = (nx as u32, ny as u32);
+        if ux >= map.width || uy >= map.height {
+            return;
+        }
+        let neighbor = map.get(ux, uy);
+        let h = neighbor.elevation as f32 * TILE_HEIGHT;
+        if h < base {
+            match &result {
+                Some((_, existing)) if *existing <= h => {}
+                _ => {
+                    result = Some((dir, h));
+                }
+            }
+        }
+    };
+
+    consider(Direction::North, x as i32, y as i32 - 1);
+    consider(Direction::South, x as i32, y as i32 + 1);
+    consider(Direction::West, x as i32 - 1, y as i32);
+    consider(Direction::East, x as i32 + 1, y as i32);
+    result
+}
+
+fn push_quad(
+    positions: &mut Vec<[f32; 3]>,
+    normals: &mut Vec<[f32; 3]>,
+    uvs: &mut Vec<[f32; 2]>,
+    indices: &mut Vec<u32>,
+    next_index: &mut u32,
+    verts: [Vec3; 4],
+    tex: [[f32; 2]; 4],
+) {
+    push_triangle(
+        positions, normals, uvs, indices, next_index, verts[0], verts[1], verts[2], tex[0], tex[1],
+        tex[2],
+    );
+    push_triangle(
+        positions, normals, uvs, indices, next_index, verts[0], verts[2], verts[3], tex[0], tex[2],
+        tex[3],
+    );
+}
+
+fn push_triangle(
+    positions: &mut Vec<[f32; 3]>,
+    normals: &mut Vec<[f32; 3]>,
+    uvs: &mut Vec<[f32; 2]>,
+    indices: &mut Vec<u32>,
+    next_index: &mut u32,
+    a: Vec3,
+    b: Vec3,
+    c: Vec3,
+    ta: [f32; 2],
+    tb: [f32; 2],
+    tc: [f32; 2],
+) {
+    let normal = (b - a).cross(c - a).normalize_or_zero();
+    positions.push(a.to_array());
+    positions.push(b.to_array());
+    positions.push(c.to_array());
+    normals.push(normal.to_array());
+    normals.push(normal.to_array());
+    normals.push(normal.to_array());
+    uvs.push(ta);
+    uvs.push(tb);
+    uvs.push(tc);
+    indices.extend_from_slice(&[*next_index, *next_index + 1, *next_index + 2]);
+    *next_index += 3;
+}
+
+fn add_side_face(
+    positions: &mut Vec<[f32; 3]>,
+    normals: &mut Vec<[f32; 3]>,
+    uvs: &mut Vec<[f32; 2]>,
+    indices: &mut Vec<u32>,
+    next_index: &mut u32,
+    top_a: Vec3,
+    top_b: Vec3,
+    bottom_a: Vec3,
+    bottom_b: Vec3,
+    direction: Direction,
+) {
+    const EPS: f32 = 1e-4;
+    if (top_a.y - bottom_a.y).abs() < EPS && (top_b.y - bottom_b.y).abs() < EPS {
+        return;
+    }
+
+    let (verts, tex) = match direction {
+        Direction::North => (
+            [top_a, top_b, bottom_b, bottom_a],
+            [[0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
+        ),
+        Direction::South => (
+            [top_a, top_b, bottom_b, bottom_a],
+            [[0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
+        ),
+        Direction::West => (
+            [top_a, top_b, bottom_b, bottom_a],
+            [[0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
+        ),
+        Direction::East => (
+            [top_a, top_b, bottom_b, bottom_a],
+            [[0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
+        ),
+    };
+
+    push_quad(positions, normals, uvs, indices, next_index, verts, tex);
+}

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -1,6 +1,7 @@
 use crate::types::{TILE_HEIGHT, TILE_SIZE, TileKind, TileMap};
 use bevy::prelude::*;
 use bevy::render::mesh::Indices;
+use bevy::render::render_asset::RenderAssetUsages;
 
 enum Direction {
     North,
@@ -16,7 +17,10 @@ const CORNER_SE: usize = 3;
 
 pub fn build_map_mesh(map: &TileMap) -> Mesh {
     if map.width == 0 || map.height == 0 {
-        return Mesh::new(bevy::render::render_resource::PrimitiveTopology::TriangleList);
+        return Mesh::new(
+            bevy::render::render_resource::PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        );
     }
 
     // Cache corner heights for every tile so we can stitch seams reliably.
@@ -167,7 +171,10 @@ pub fn build_map_mesh(map: &TileMap) -> Mesh {
         }
     }
 
-    let mut mesh = Mesh::new(bevy::render::render_resource::PrimitiveTopology::TriangleList);
+    let mut mesh = Mesh::new(
+        bevy::render::render_resource::PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    );
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
     mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);


### PR DESCRIPTION
## Summary
- add a reusable terrain mesh entity and material for the editor
- rebuild the mesh from the tile map, extruding cliffs and smoothing ramp transitions

## Testing
- `cargo fmt`
- `cargo check` *(fails: missing system library `alsa` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d799688a88833288cc9a042b00f135