### PR TITLE
Fix ramp alignment and add rotation tool

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -28,6 +28,7 @@ pub struct EditorState {
     pub hover: Option<(u32, u32)>,
     pub map: TileMap,
     pub map_dirty: bool,
+    pub rotate_mode: bool,
 }
 impl Default for EditorState {
     fn default() -> Self {
@@ -37,6 +38,7 @@ impl Default for EditorState {
             hover: None,
             map: TileMap::new(64, 64),
             map_dirty: true,
+            rotate_mode: false,
         }
     }
 }
@@ -128,26 +130,50 @@ fn paint_tiles(
     if egui.ctx_mut().wants_pointer_input() {
         return;
     }
+
+    if state.rotate_mode {
+        if buttons.just_pressed(MouseButton::Left) {
+            if let Some((x, y)) = state.hover {
+                let idx = state.map.idx(x, y);
+                let tile = state.map.tiles[idx].clone();
+                if tile.kind == TileKind::Ramp {
+                    let mut updated = tile.clone();
+                    updated.orientation = tile.orientation.next();
+                    updated.manual_orientation = true;
+                    state.map.tiles[idx] = updated;
+                    state.map_dirty = true;
+                }
+            }
+        }
+        return;
+    }
+
     if buttons.pressed(MouseButton::Left) {
         if let Some((x, y)) = state.hover {
             let kind = state.current_kind;
             let elevation = state.current_elev;
             let state_ref = &mut *state;
-            let current = state_ref.map.get(x, y);
+            let idx = state_ref.map.idx(x, y);
+            let mut current = state_ref.map.tiles[idx].clone();
             if current.kind != kind || current.elevation != elevation {
-                let tile_type = current.tile_type.clone();
-                state_ref.map.set(
-                    x,
-                    y,
-                    Tile {
-                        kind,
-                        elevation,
-                        tile_type,
-                        x,
-                        y,
-                    },
-                );
+                current.kind = kind;
+                current.elevation = elevation;
+                current.x = x;
+                current.y = y;
+                match kind {
+                    TileKind::Ramp => {
+                        current.manual_orientation = false;
+                    }
+                    TileKind::Floor => {
+                        current.manual_orientation = false;
+                        current.orientation = Orientation4::North;
+                    }
+                }
+                state_ref.map.tiles[idx] = current;
                 state_ref.map_dirty = true;
+                if auto_orient_around(&mut state_ref.map, x, y) {
+                    state_ref.map_dirty = true;
+                }
             }
         }
     }
@@ -207,4 +233,97 @@ fn draw_hover_highlight(
             HoverMarker,
         ));
     }
+}
+
+pub fn auto_orient_entire_map(map: &mut TileMap) -> bool {
+    let mut changed = false;
+    for y in 0..map.height {
+        for x in 0..map.width {
+            changed |= auto_orient_tile(map, x, y);
+        }
+    }
+    changed
+}
+
+fn auto_orient_around(map: &mut TileMap, x: u32, y: u32) -> bool {
+    let mut changed = false;
+    let mut consider = |tx: i32, ty: i32| {
+        if tx < 0 || ty < 0 {
+            return;
+        }
+        let (ux, uy) = (tx as u32, ty as u32);
+        if ux >= map.width || uy >= map.height {
+            return;
+        }
+        changed |= auto_orient_tile(map, ux, uy);
+    };
+
+    consider(x as i32, y as i32);
+    consider(x as i32 - 1, y as i32);
+    consider(x as i32 + 1, y as i32);
+    consider(x as i32, y as i32 - 1);
+    consider(x as i32, y as i32 + 1);
+
+    changed
+}
+
+fn auto_orient_tile(map: &mut TileMap, x: u32, y: u32) -> bool {
+    let idx = map.idx(x, y);
+    let tile = map.tiles[idx].clone();
+    if tile.kind != TileKind::Ramp || tile.manual_orientation {
+        return false;
+    }
+
+    if let Some(orientation) = best_orientation(map, x, y) {
+        if tile.orientation != orientation {
+            map.tiles[idx].orientation = orientation;
+            return true;
+        }
+    }
+
+    false
+}
+
+fn best_orientation(map: &TileMap, x: u32, y: u32) -> Option<Orientation4> {
+    const EPS: f32 = 1e-4;
+    let base = map.get(x, y).elevation as f32 * TILE_HEIGHT;
+    let mut best: Option<(Orientation4, f32)> = None;
+
+    for orientation in [
+        Orientation4::North,
+        Orientation4::East,
+        Orientation4::South,
+        Orientation4::West,
+    ] {
+        let (dx, dy) = match orientation {
+            Orientation4::North => (0, -1),
+            Orientation4::East => (1, 0),
+            Orientation4::South => (0, 1),
+            Orientation4::West => (-1, 0),
+        };
+        let nx = x as i32 + dx;
+        let ny = y as i32 + dy;
+        if nx < 0 || ny < 0 {
+            continue;
+        }
+        let (ux, uy) = (nx as u32, ny as u32);
+        if ux >= map.width || uy >= map.height {
+            continue;
+        }
+        let neighbor = map.get(ux, uy);
+        let h = neighbor.elevation as f32 * TILE_HEIGHT;
+        if h > base {
+            let diff = h - base;
+            match best {
+                None => best = Some((orientation, diff)),
+                Some((_, best_diff)) => {
+                    if diff + EPS < best_diff {
+                        best = Some((orientation, diff));
+                    }
+                }
+            }
+        }
+    }
+
+    best.map(|(orientation, _)| orientation)
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -60,12 +60,12 @@ fn spawn_editor_assets(
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     let hover = mats.add(StandardMaterial {
-        base_color: Color::rgba(0.0, 1.0, 0.0, 0.25),
+        base_color: Color::srgba(0.0, 1.0, 0.0, 0.25),
         unlit: true,
         ..default()
     });
     let terrain_material = mats.add(StandardMaterial {
-        base_color: Color::rgb(0.35, 0.55, 0.2),
+        base_color: Color::srgb(0.35, 0.55, 0.2),
         perceptual_roughness: 0.8,
         metallic: 0.0,
         ..default()

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,6 @@
-use bincode::{config, encode_to_vec, decode_from_slice};
-use serde::{Serialize, Deserialize};
 use crate::types::TileMap;
+use bincode::{config, decode_from_slice, encode_to_vec};
+use serde::{Deserialize, Serialize};
 
 const KEY: u8 = 0xAA;
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,5 @@
 use crate::types::TileMap;
-use bincode::{config, decode_from_slice, encode_to_vec};
-use serde::{Deserialize, Serialize};
+use bincode::{config, serde::decode_from_slice, serde::encode_to_vec};
 
 const KEY: u8 = 0xAA;
 

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -214,7 +214,7 @@ fn find_ramp_target(
 ) -> Option<(Direction, f32)> {
     const EPS: f32 = 1e-4;
 
-    let mut consider = |dir: Direction| -> Option<(Direction, f32, f32)> {
+    let consider = |dir: Direction| -> Option<(Direction, f32, f32)> {
         let (dx, dy) = neighbor_offset(dir);
         let nx = x as i32 + dx;
         let ny = y as i32 + dy;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,13 +1,12 @@
-use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug, Encode, Decode)]
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub enum TileKind {
     Floor,
     Ramp,
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug, Encode, Decode, Default)]
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug, Default)]
 pub enum Orientation4 {
     #[default]
     North,
@@ -27,7 +26,7 @@ impl Orientation4 {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Tile {
     pub kind: TileKind,
     pub tile_type: TileType,
@@ -35,14 +34,12 @@ pub struct Tile {
     pub y: u32,
     pub elevation: i8, // can be negative for underwater, or positive for cliffs
     #[serde(default)]
-    #[bincode(default)]
     pub orientation: Orientation4,
     #[serde(default)]
-    #[bincode(default)]
     pub manual_orientation: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum TileType {
     Grass,
     Dirt,
@@ -50,7 +47,7 @@ pub enum TileType {
     Water,
 }
 
-#[derive(Serialize, Deserialize, Debug, Encode, Decode)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct TileMap {
     pub width: u32,
     pub height: u32,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,30 +1,53 @@
+use crate::io::{load_map, save_map};
+use crate::types::*;
 use bevy::prelude::*;
 use bevy_egui::{EguiContexts, egui};
-use crate::types::*;
-use crate::io::{save_map, load_map};
 
 pub struct UiPlugin;
 impl Plugin for UiPlugin {
-    fn build(&self, app: &mut App) { app.add_systems(Update, ui_panel); }
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, ui_panel);
+    }
 }
 
-fn ui_panel(
-    mut egui_ctx: EguiContexts,
-    mut state: ResMut<crate::editor::EditorState>,
-){
+fn ui_panel(mut egui_ctx: EguiContexts, mut state: ResMut<crate::editor::EditorState>) {
     egui::TopBottomPanel::top("toolbar").show(egui_ctx.ctx_mut(), |ui| {
         ui.horizontal(|ui| {
             ui.label("Tool:");
-            ui.selectable_value(&mut state.current_kind, TileKind::Floor, "Floor");
-            ui.selectable_value(&mut state.current_kind, TileKind::Ramp, "Ramp");
+            let floor_selected = !state.rotate_mode && state.current_kind == TileKind::Floor;
+            if ui.selectable_label(floor_selected, "Floor").clicked() {
+                state.rotate_mode = false;
+                state.current_kind = TileKind::Floor;
+            }
+            let ramp_selected = !state.rotate_mode && state.current_kind == TileKind::Ramp;
+            if ui.selectable_label(ramp_selected, "Ramp").clicked() {
+                state.rotate_mode = false;
+                state.current_kind = TileKind::Ramp;
+            }
+            if ui
+                .selectable_label(state.rotate_mode, "Rotate Ramp")
+                .clicked()
+            {
+                state.rotate_mode = true;
+            }
 
             ui.separator();
             ui.label("Elevation:");
-            for e in 0..=3 { ui.selectable_value(&mut state.current_elev, e, format!("{e}")); }
+            for e in 0..=3 {
+                ui.selectable_value(&mut state.current_elev, e, format!("{e}"));
+            }
 
             ui.separator();
-            if ui.button("Save").clicked() { save_map("map.json", &state.map).ok(); }
-            if ui.button("Load").clicked() { if let Ok(m)=load_map("map.json"){ state.map = m; } }
+            if ui.button("Save").clicked() {
+                save_map("map.json", &state.map).ok();
+            }
+            if ui.button("Load").clicked() {
+                if let Ok(mut m) = load_map("map.json") {
+                    crate::editor::auto_orient_entire_map(&mut m);
+                    state.map = m;
+                    state.map_dirty = true;
+                }
+            }
         });
     });
 }


### PR DESCRIPTION
## Summary
- track ramp orientation on each tile, auto-orient ramps toward the nearest higher neighbor, and expose helpers to refresh orientations when maps load
- update terrain mesh building to respect manual ramp rotations while defaulting to higher adjacent elevations
- add a rotate-ramp tool in the UI and editing logic so ramps can be cycled between directions without repainting

## Testing
- `cargo fmt`
- `cargo check` *(fails: missing system library `alsa` for crate `alsa-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68d82d9b080c83329fe963931ade3ab0