### PR TITLE
Add ramp auto alignment and rotation tooling

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,6 @@
-use bincode::{config, encode_to_vec, decode_from_slice};
-use serde::{Serialize, Deserialize};
 use crate::types::TileMap;
+use bincode::{config, decode_from_slice, encode_to_vec};
+use serde::{Deserialize, Serialize};
 
 const KEY: u8 = 0xAA;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,45 @@ use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug, Encode, Decode)]
-pub enum TileKind { Floor, Ramp }
+pub enum TileKind {
+    Floor,
+    Ramp,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug, Encode, Decode)]
+pub enum CardinalDirection {
+    North,
+    East,
+    South,
+    West,
+}
+
+impl CardinalDirection {
+    pub const ALL: [Self; 4] = [
+        CardinalDirection::North,
+        CardinalDirection::East,
+        CardinalDirection::South,
+        CardinalDirection::West,
+    ];
+
+    pub fn next(self) -> Self {
+        match self {
+            CardinalDirection::North => CardinalDirection::East,
+            CardinalDirection::East => CardinalDirection::South,
+            CardinalDirection::South => CardinalDirection::West,
+            CardinalDirection::West => CardinalDirection::North,
+        }
+    }
+
+    pub fn offset(self) -> (i32, i32) {
+        match self {
+            CardinalDirection::North => (0, -1),
+            CardinalDirection::East => (1, 0),
+            CardinalDirection::South => (0, 1),
+            CardinalDirection::West => (-1, 0),
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode)]
 pub struct Tile {
@@ -10,7 +48,8 @@ pub struct Tile {
     pub tile_type: TileType,
     pub x: u32,
     pub y: u32,
-    pub elevation: i8,   // can be negative for underwater, or positive for cliffs
+    pub elevation: i8, // can be negative for underwater, or positive for cliffs
+    pub ramp_orientation: Option<CardinalDirection>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode)]
@@ -31,17 +70,32 @@ pub struct TileMap {
 impl TileMap {
     pub fn new(w: u32, h: u32) -> Self {
         Self {
-            width: w, height: h,
-            tiles: vec![Tile { kind: TileKind::Floor, tile_type: TileType::Grass, elevation: 0, x: 0, y: 0}; (w*h) as usize],
+            width: w,
+            height: h,
+            tiles: vec![
+                Tile {
+                    kind: TileKind::Floor,
+                    tile_type: TileType::Grass,
+                    elevation: 0,
+                    x: 0,
+                    y: 0,
+                    ramp_orientation: None,
+                };
+                (w * h) as usize
+            ],
         }
     }
-    pub fn idx(&self, x:u32,y:u32)->usize { (y*self.width + x) as usize }
-    pub fn get(&self, x:u32,y:u32)->&Tile { &self.tiles[self.idx(x,y)] }
-    pub fn set(&mut self, x:u32,y:u32, t:Tile){
+    pub fn idx(&self, x: u32, y: u32) -> usize {
+        (y * self.width + x) as usize
+    }
+    pub fn get(&self, x: u32, y: u32) -> &Tile {
+        &self.tiles[self.idx(x, y)]
+    }
+    pub fn set(&mut self, x: u32, y: u32, t: Tile) {
         let i = self.idx(x, y);
         self.tiles[i] = t;
     }
 }
 
-pub const TILE_SIZE: f32 = 1.0;     // world units per tile
-pub const TILE_HEIGHT: f32 = 1.0;   // height per elevation step
+pub const TILE_SIZE: f32 = 1.0; // world units per tile
+pub const TILE_HEIGHT: f32 = 1.0; // height per elevation step

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,30 +1,46 @@
 use bevy::prelude::*;
 use bevy_egui::{EguiContexts, egui};
+
+use crate::editor::EditorTool;
+use crate::io::{load_map, save_map};
 use crate::types::*;
-use crate::io::{save_map, load_map};
 
 pub struct UiPlugin;
 impl Plugin for UiPlugin {
-    fn build(&self, app: &mut App) { app.add_systems(Update, ui_panel); }
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, ui_panel);
+    }
 }
 
-fn ui_panel(
-    mut egui_ctx: EguiContexts,
-    mut state: ResMut<crate::editor::EditorState>,
-){
+fn ui_panel(mut egui_ctx: EguiContexts, mut state: ResMut<crate::editor::EditorState>) {
     egui::TopBottomPanel::top("toolbar").show(egui_ctx.ctx_mut(), |ui| {
         ui.horizontal(|ui| {
             ui.label("Tool:");
-            ui.selectable_value(&mut state.current_kind, TileKind::Floor, "Floor");
-            ui.selectable_value(&mut state.current_kind, TileKind::Ramp, "Ramp");
+            ui.selectable_value(&mut state.current_tool, EditorTool::Paint, "Paint");
+            ui.selectable_value(&mut state.current_tool, EditorTool::Rotate, "Rotate");
+
+            if state.current_tool == EditorTool::Paint {
+                ui.separator();
+                ui.label("Tile:");
+                ui.selectable_value(&mut state.current_kind, TileKind::Floor, "Floor");
+                ui.selectable_value(&mut state.current_kind, TileKind::Ramp, "Ramp");
+
+                ui.separator();
+                ui.label("Elevation:");
+                for e in 0..=3 {
+                    ui.selectable_value(&mut state.current_elev, e, format!("{e}"));
+                }
+            }
 
             ui.separator();
-            ui.label("Elevation:");
-            for e in 0..=3 { ui.selectable_value(&mut state.current_elev, e, format!("{e}")); }
-
-            ui.separator();
-            if ui.button("Save").clicked() { save_map("map.json", &state.map).ok(); }
-            if ui.button("Load").clicked() { if let Ok(m)=load_map("map.json"){ state.map = m; } }
+            if ui.button("Save").clicked() {
+                save_map("map.json", &state.map).ok();
+            }
+            if ui.button("Load").clicked() {
+                if let Ok(m) = load_map("map.json") {
+                    state.map = m;
+                }
+            }
         });
     });
 }


### PR DESCRIPTION
## Summary
- add persistent ramp orientation data and automatically align ramps to the nearest higher neighbor
- add a rotate tool plus right-click/R shortcuts so ramps can be cycled through orientations
- update the toolbar to expose the rotate tool alongside paint options

## Testing
- cargo check *(fails: `alsa` system library missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c2d802208332a79ed0f2468e2cee