### PR TITLE
Add ramp auto orientation and rotation controls

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,6 @@
-use bincode::{config, encode_to_vec, decode_from_slice};
-use serde::{Serialize, Deserialize};
 use crate::types::TileMap;
+use bincode::{config, decode_from_slice, encode_to_vec};
+use serde::{Deserialize, Serialize};
 
 const KEY: u8 = 0xAA;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,45 @@ use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug, Encode, Decode)]
-pub enum TileKind { Floor, Ramp }
+pub enum TileKind {
+    Floor,
+    Ramp,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug, Encode, Decode)]
+pub enum Direction {
+    North,
+    East,
+    South,
+    West,
+}
+
+impl Direction {
+    pub const ALL: [Direction; 4] = [
+        Direction::North,
+        Direction::East,
+        Direction::South,
+        Direction::West,
+    ];
+
+    pub fn clockwise(self) -> Self {
+        match self {
+            Direction::North => Direction::East,
+            Direction::East => Direction::South,
+            Direction::South => Direction::West,
+            Direction::West => Direction::North,
+        }
+    }
+
+    pub fn offset(self) -> (i32, i32) {
+        match self {
+            Direction::North => (0, -1),
+            Direction::East => (1, 0),
+            Direction::South => (0, 1),
+            Direction::West => (-1, 0),
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode)]
 pub struct Tile {
@@ -10,7 +48,8 @@ pub struct Tile {
     pub tile_type: TileType,
     pub x: u32,
     pub y: u32,
-    pub elevation: i8,   // can be negative for underwater, or positive for cliffs
+    pub elevation: i8, // can be negative for underwater, or positive for cliffs
+    pub rotation: Direction,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode)]
@@ -31,17 +70,32 @@ pub struct TileMap {
 impl TileMap {
     pub fn new(w: u32, h: u32) -> Self {
         Self {
-            width: w, height: h,
-            tiles: vec![Tile { kind: TileKind::Floor, tile_type: TileType::Grass, elevation: 0, x: 0, y: 0}; (w*h) as usize],
+            width: w,
+            height: h,
+            tiles: vec![
+                Tile {
+                    kind: TileKind::Floor,
+                    tile_type: TileType::Grass,
+                    x: 0,
+                    y: 0,
+                    elevation: 0,
+                    rotation: Direction::North,
+                };
+                (w * h) as usize
+            ],
         }
     }
-    pub fn idx(&self, x:u32,y:u32)->usize { (y*self.width + x) as usize }
-    pub fn get(&self, x:u32,y:u32)->&Tile { &self.tiles[self.idx(x,y)] }
-    pub fn set(&mut self, x:u32,y:u32, t:Tile){
+    pub fn idx(&self, x: u32, y: u32) -> usize {
+        (y * self.width + x) as usize
+    }
+    pub fn get(&self, x: u32, y: u32) -> &Tile {
+        &self.tiles[self.idx(x, y)]
+    }
+    pub fn set(&mut self, x: u32, y: u32, t: Tile) {
         let i = self.idx(x, y);
         self.tiles[i] = t;
     }
 }
 
-pub const TILE_SIZE: f32 = 1.0;     // world units per tile
-pub const TILE_HEIGHT: f32 = 1.0;   // height per elevation step
+pub const TILE_SIZE: f32 = 1.0; // world units per tile
+pub const TILE_HEIGHT: f32 = 1.0; // height per elevation step

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,30 +1,43 @@
+use crate::editor::EditorTool;
+use crate::io::{load_map, save_map};
+use crate::types::*;
 use bevy::prelude::*;
 use bevy_egui::{EguiContexts, egui};
-use crate::types::*;
-use crate::io::{save_map, load_map};
 
 pub struct UiPlugin;
 impl Plugin for UiPlugin {
-    fn build(&self, app: &mut App) { app.add_systems(Update, ui_panel); }
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, ui_panel);
+    }
 }
 
-fn ui_panel(
-    mut egui_ctx: EguiContexts,
-    mut state: ResMut<crate::editor::EditorState>,
-){
+fn ui_panel(mut egui_ctx: EguiContexts, mut state: ResMut<crate::editor::EditorState>) {
     egui::TopBottomPanel::top("toolbar").show(egui_ctx.ctx_mut(), |ui| {
         ui.horizontal(|ui| {
-            ui.label("Tool:");
+            ui.label("Mode:");
+            ui.selectable_value(&mut state.current_tool, EditorTool::Paint, "Paint");
+            ui.selectable_value(&mut state.current_tool, EditorTool::Rotate, "Rotate Ramp");
+
+            ui.separator();
+            ui.label("Tile:");
             ui.selectable_value(&mut state.current_kind, TileKind::Floor, "Floor");
             ui.selectable_value(&mut state.current_kind, TileKind::Ramp, "Ramp");
 
             ui.separator();
             ui.label("Elevation:");
-            for e in 0..=3 { ui.selectable_value(&mut state.current_elev, e, format!("{e}")); }
+            for e in 0..=3 {
+                ui.selectable_value(&mut state.current_elev, e, format!("{e}"));
+            }
 
             ui.separator();
-            if ui.button("Save").clicked() { save_map("map.json", &state.map).ok(); }
-            if ui.button("Load").clicked() { if let Ok(m)=load_map("map.json"){ state.map = m; } }
+            if ui.button("Save").clicked() {
+                save_map("map.json", &state.map).ok();
+            }
+            if ui.button("Load").clicked() {
+                if let Ok(m) = load_map("map.json") {
+                    state.map = m;
+                }
+            }
         });
     });
 }


### PR DESCRIPTION
## Summary
- store a rotation direction on tiles and expose helpers to find neighbouring ramp targets
- default new ramps to face the nearest higher neighbour when painting
- add a rotate tool plus right-click/`R` shortcuts for cycling ramp orientation and surface those options in the toolbar

## Testing
- cargo check *(fails: missing system dependency `alsa`)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c2d802208332a79ed0f2468e2cee