### PR TITLE
Scale elevation height relative to tile width

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -44,4 +44,5 @@ impl TileMap {
 }
 
 pub const TILE_SIZE: f32 = 1.0;     // world units per tile
-pub const TILE_HEIGHT: f32 = 1.0;   // height per elevation step
+pub const ELEVATION_FRACTION: f32 = 0.4; // fraction of tile width per elevation step
+pub const TILE_HEIGHT: f32 = TILE_SIZE * ELEVATION_FRACTION;   // height per elevation step


### PR DESCRIPTION
## Summary
- define an elevation fraction constant to represent 40% of a tile width per elevation step
- derive tile height from tile width and the elevation fraction to keep map elevation proportional

## Testing
- cargo test *(fails: missing system dependency `alsa`)*

------
https://chatgpt.com/codex/tasks/task_e_68d8cec05eb88332bc2dc3a0427e3c9b