### PR TITLE
Ensure hover highlight renders above terrain

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,5 +1,6 @@
 use crate::terrain;
 use crate::types::*;
+use bevy::gizmos::GizmoConfigStore;
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssetUsages;
 use bevy_egui::EguiContexts;
@@ -8,7 +9,9 @@ pub struct EditorPlugin;
 impl Plugin for EditorPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<EditorState>()
+            .init_gizmo_group::<HoverGizmoGroup>()
             .add_systems(Startup, spawn_editor_assets)
+            .add_systems(Startup, configure_hover_gizmos)
             .add_systems(
                 Update,
                 (
@@ -53,6 +56,15 @@ impl Default for EditorState {
 #[derive(Resource)]
 struct TerrainVisual {
     mesh: Handle<Mesh>,
+}
+
+#[derive(Default, Reflect, GizmoConfigGroup)]
+#[reflect(Default)]
+struct HoverGizmoGroup;
+
+fn configure_hover_gizmos(mut configs: ResMut<GizmoConfigStore>) {
+    let (config, _) = configs.config_mut::<HoverGizmoGroup>();
+    config.depth_bias = -1.0;
 }
 
 fn spawn_editor_assets(
@@ -293,7 +305,7 @@ fn rebuild_terrain_mesh(
     }
 }
 
-fn draw_hover_highlight(mut gizmos: Gizmos, state: Res<EditorState>) {
+fn draw_hover_highlight(mut gizmos: Gizmos<HoverGizmoGroup>, state: Res<EditorState>) {
     if let Some((x, y)) = state.hover {
         let heights = terrain::tile_corner_heights(&state.map, x, y);
         let offset = 0.02;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,6 +1,5 @@
 use crate::terrain;
 use crate::types::*;
-use bevy::gizmos::GizmoConfigStore;
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssetUsages;
 use bevy_egui::EguiContexts;

--- a/src/types.rs
+++ b/src/types.rs
@@ -98,7 +98,6 @@ impl TileMap {
     }
 }
 
-pub const TILE_SIZE: f32 = 1.0;     // world units per tile
+pub const TILE_SIZE: f32 = 1.0; // world units per tile
 pub const ELEVATION_FRACTION: f32 = 0.4; // fraction of tile width per elevation step
-pub const TILE_HEIGHT: f32 = TILE_SIZE * ELEVATION_FRACTION;   // height per elevation step
-
+pub const TILE_HEIGHT: f32 = TILE_SIZE * ELEVATION_FRACTION; // height per elevation step


### PR DESCRIPTION
## Summary
- create a dedicated gizmo group for the hover highlight and force it to render in front of scene geometry
- configure the editor to initialize the gizmo group and use it when drawing the hover outline

## Testing
- cargo fmt
- cargo check *(fails: missing system library `alsa` in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d46a93808332b6efe56c72ee9709