### PR TITLE
Add splatmap-based terrain rendering with world-space UVs

### DIFF
--- a/assets/shaders/terrain_blend_extension.wgsl
+++ b/assets/shaders/terrain_blend_extension.wgsl
@@ -1,0 +1,102 @@
+#import bevy_pbr::{
+    pbr_fragment::pbr_input_from_standard_material,
+    pbr_functions::{alpha_discard, apply_pbr_lighting, main_pass_post_lighting_processing},
+};
+
+#ifdef PREPASS_PIPELINE
+#import bevy_pbr::{
+    prepass_io::{VertexOutput, FragmentOutput},
+    pbr_deferred_functions::deferred_output,
+};
+#else
+#import bevy_pbr::{
+    forward_io::{VertexOutput, FragmentOutput},
+};
+#endif
+
+struct TerrainBlendParams {
+    uv_scale: f32,
+    inv_map_width: f32,
+    inv_map_height: f32,
+    _padding: f32,
+    layer_tints: array<vec4<f32>, 4>,
+}
+
+@group(2) @binding(100)
+var<uniform> terrain_params: TerrainBlendParams;
+
+@group(2) @binding(101)
+var terrain_splatmap: texture_2d<f32>;
+@group(2) @binding(102)
+var terrain_splatmap_sampler: sampler;
+
+@group(2) @binding(103)
+var terrain_layer0: texture_2d<f32>;
+@group(2) @binding(104)
+var terrain_layer0_sampler: sampler;
+
+@group(2) @binding(105)
+var terrain_layer1: texture_2d<f32>;
+@group(2) @binding(106)
+var terrain_layer1_sampler: sampler;
+
+@group(2) @binding(107)
+var terrain_layer2: texture_2d<f32>;
+@group(2) @binding(108)
+var terrain_layer2_sampler: sampler;
+
+@group(2) @binding(109)
+var terrain_layer3: texture_2d<f32>;
+@group(2) @binding(110)
+var terrain_layer3_sampler: sampler;
+
+fn splat_weights(world_position: vec3<f32>) -> vec4<f32> {
+    let splat_uv = vec2<f32>(
+        world_position.x * terrain_params.inv_map_width,
+        world_position.z * terrain_params.inv_map_height,
+    );
+    var weights = textureSample(terrain_splatmap, terrain_splatmap_sampler, splat_uv);
+    let weight_sum = max(dot(weights, vec4<f32>(1.0)), 1e-4);
+    return weights / weight_sum;
+}
+
+fn blended_color(weights: vec4<f32>, uv: vec2<f32>) -> vec4<f32> {
+    var color = vec4<f32>(0.0);
+    color += textureSample(terrain_layer0, terrain_layer0_sampler, uv)
+        * terrain_params.layer_tints[0]
+        * weights.x;
+    color += textureSample(terrain_layer1, terrain_layer1_sampler, uv)
+        * terrain_params.layer_tints[1]
+        * weights.y;
+    color += textureSample(terrain_layer2, terrain_layer2_sampler, uv)
+        * terrain_params.layer_tints[2]
+        * weights.z;
+    color += textureSample(terrain_layer3, terrain_layer3_sampler, uv)
+        * terrain_params.layer_tints[3]
+        * weights.w;
+    return color;
+}
+
+@fragment
+fn fragment(
+    in: VertexOutput,
+    @builtin(front_facing) is_front: bool,
+) -> FragmentOutput {
+    var pbr_input = pbr_input_from_standard_material(in, is_front);
+
+    let weights = splat_weights(in.world_position.xyz);
+    let scale = max(terrain_params.uv_scale, 1e-4);
+    let tiled_uv = in.uv / scale;
+    let surface_color = blended_color(weights, tiled_uv);
+    pbr_input.material.base_color = alpha_discard(pbr_input.material, surface_color);
+
+#ifdef PREPASS_PIPELINE
+    let out = deferred_output(in, pbr_input);
+#else
+    var out: FragmentOutput;
+    out.color = apply_pbr_lighting(pbr_input);
+    out.color = main_pass_post_lighting_processing(pbr_input, out.color);
+#endif
+
+    return out;
+}

--- a/assets/shaders/terrain_blend_extension.wgsl
+++ b/assets/shaders/terrain_blend_extension.wgsl
@@ -33,22 +33,13 @@ var terrain_splatmap_sampler: sampler;
 @group(2) @binding(103)
 var terrain_layer0: texture_2d<f32>;
 @group(2) @binding(104)
-var terrain_layer0_sampler: sampler;
-
-@group(2) @binding(105)
 var terrain_layer1: texture_2d<f32>;
-@group(2) @binding(106)
-var terrain_layer1_sampler: sampler;
-
-@group(2) @binding(107)
+@group(2) @binding(105)
 var terrain_layer2: texture_2d<f32>;
-@group(2) @binding(108)
-var terrain_layer2_sampler: sampler;
-
-@group(2) @binding(109)
+@group(2) @binding(106)
 var terrain_layer3: texture_2d<f32>;
-@group(2) @binding(110)
-var terrain_layer3_sampler: sampler;
+@group(2) @binding(107)
+var terrain_layer_sampler: sampler;
 
 fn splat_weights(world_position: vec3<f32>) -> vec4<f32> {
     let splat_uv = vec2<f32>(
@@ -62,16 +53,16 @@ fn splat_weights(world_position: vec3<f32>) -> vec4<f32> {
 
 fn blended_color(weights: vec4<f32>, uv: vec2<f32>) -> vec4<f32> {
     var color = vec4<f32>(0.0);
-    color += textureSample(terrain_layer0, terrain_layer0_sampler, uv)
+    color += textureSample(terrain_layer0, terrain_layer_sampler, uv)
         * terrain_params.layer_tints[0]
         * weights.x;
-    color += textureSample(terrain_layer1, terrain_layer1_sampler, uv)
+    color += textureSample(terrain_layer1, terrain_layer_sampler, uv)
         * terrain_params.layer_tints[1]
         * weights.y;
-    color += textureSample(terrain_layer2, terrain_layer2_sampler, uv)
+    color += textureSample(terrain_layer2, terrain_layer_sampler, uv)
         * terrain_params.layer_tints[2]
         * weights.z;
-    color += textureSample(terrain_layer3, terrain_layer3_sampler, uv)
+    color += textureSample(terrain_layer3, terrain_layer_sampler, uv)
         * terrain_params.layer_tints[3]
         * weights.w;
     return color;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -148,10 +148,28 @@ fn spawn_editor_assets(
                 layer_tints,
             },
             splatmap: splatmap_handle.clone(),
+            splatmap_sampler: ImageSampler::Descriptor(ImageSamplerDescriptor {
+                address_mode_u: ImageAddressMode::ClampToEdge,
+                address_mode_v: ImageAddressMode::ClampToEdge,
+                address_mode_w: ImageAddressMode::ClampToEdge,
+                mag_filter: ImageFilterMode::Linear,
+                min_filter: ImageFilterMode::Linear,
+                mipmap_filter: ImageFilterMode::Linear,
+                ..Default::default()
+            }),
             layer0: layer_handles[0].clone(),
             layer1: layer_handles[1].clone(),
             layer2: layer_handles[2].clone(),
             layer3: layer_handles[3].clone(),
+            layer_sampler: ImageSampler::Descriptor(ImageSamplerDescriptor {
+                address_mode_u: ImageAddressMode::Repeat,
+                address_mode_v: ImageAddressMode::Repeat,
+                address_mode_w: ImageAddressMode::Repeat,
+                mag_filter: ImageFilterMode::Linear,
+                min_filter: ImageFilterMode::Linear,
+                mipmap_filter: ImageFilterMode::Linear,
+                ..Default::default()
+            }),
         },
     });
 
@@ -406,6 +424,24 @@ fn rebuild_terrain_mesh(
         };
         material.extension.splatmap = visual.splatmap.clone();
         material.extension.set_layer_handles(&layer_handles);
+        material.extension.splatmap_sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+            address_mode_u: ImageAddressMode::ClampToEdge,
+            address_mode_v: ImageAddressMode::ClampToEdge,
+            address_mode_w: ImageAddressMode::ClampToEdge,
+            mag_filter: ImageFilterMode::Linear,
+            min_filter: ImageFilterMode::Linear,
+            mipmap_filter: ImageFilterMode::Linear,
+            ..Default::default()
+        });
+        material.extension.layer_sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+            address_mode_u: ImageAddressMode::Repeat,
+            address_mode_v: ImageAddressMode::Repeat,
+            address_mode_w: ImageAddressMode::Repeat,
+            mag_filter: ImageFilterMode::Linear,
+            min_filter: ImageFilterMode::Linear,
+            mipmap_filter: ImageFilterMode::Linear,
+            ..Default::default()
+        });
     }
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,5 @@
 use crate::types::TileMap;
 use bincode::{config, decode_from_slice, encode_to_vec};
-use serde::{Deserialize, Serialize};
 
 const KEY: u8 = 0xAA;
 

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -1,14 +1,13 @@
-use crate::types::{
-    RampDirection, TERRAIN_LAYERS, TILE_HEIGHT, TILE_SIZE, TileKind, TileMap, TileType,
-};
+use crate::types::{RampDirection, TERRAIN_LAYERS, TILE_HEIGHT, TILE_SIZE, TileKind, TileMap};
 use bevy::prelude::*;
 use bevy::render::mesh::Indices;
 use bevy::render::render_asset::RenderAssetUsages;
 use bevy::render::render_resource::{
-    AddressMode, Extent3d, FilterMode, PrimitiveTopology, SamplerDescriptor, TextureDimension,
-    TextureFormat, TextureUsages,
+    Extent3d, PrimitiveTopology, TextureDimension, TextureFormat, TextureUsages,
 };
-use bevy::render::texture::ImageSampler;
+use bevy::render::texture::{
+    ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor,
+};
 
 pub const CORNER_NW: usize = 0;
 pub const CORNER_NE: usize = 1;
@@ -164,6 +163,7 @@ pub fn build_splatmap(map: &TileMap) -> Image {
             TextureDimension::D2,
             &[255, 0, 0, 0],
             TextureFormat::Rgba8Unorm,
+            RenderAssetUsages::default(),
         );
         configure_splatmap_image(&mut image);
         return image;
@@ -191,6 +191,7 @@ pub fn build_splatmap(map: &TileMap) -> Image {
         TextureDimension::D2,
         &data,
         TextureFormat::Rgba8Unorm,
+        RenderAssetUsages::default(),
     );
     configure_splatmap_image(&mut image);
     image
@@ -199,13 +200,13 @@ pub fn build_splatmap(map: &TileMap) -> Image {
 fn configure_splatmap_image(image: &mut Image) {
     image.texture_descriptor.usage =
         TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST | TextureUsages::COPY_SRC;
-    image.sampler_descriptor = ImageSampler::Descriptor(SamplerDescriptor {
-        address_mode_u: AddressMode::ClampToEdge,
-        address_mode_v: AddressMode::ClampToEdge,
-        address_mode_w: AddressMode::ClampToEdge,
-        mag_filter: FilterMode::Linear,
-        min_filter: FilterMode::Linear,
-        mipmap_filter: FilterMode::Linear,
+    image.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+        address_mode_u: ImageAddressMode::ClampToEdge,
+        address_mode_v: ImageAddressMode::ClampToEdge,
+        address_mode_w: ImageAddressMode::ClampToEdge,
+        mag_filter: ImageFilterMode::Linear,
+        min_filter: ImageFilterMode::Linear,
+        mipmap_filter: ImageFilterMode::Linear,
         ..Default::default()
     });
 }

--- a/src/texture/material.rs
+++ b/src/texture/material.rs
@@ -1,47 +1,66 @@
+use bevy::math::Vec4;
+use bevy::pbr::{ExtendedMaterial, MaterialExtension, MaterialPlugin};
 use bevy::prelude::*;
+use bevy::reflect::TypePath;
+use bevy::render::render_resource::{AsBindGroup, ShaderRef, ShaderType};
 
-#[derive(Debug, Clone)]
-pub struct TerrainMaterialHandles {
-    pub material: Handle<StandardMaterial>,
-    pub base_color: Handle<Image>,
-    pub normal: Option<Handle<Image>>,
-    pub roughness: Option<Handle<Image>>,
-    pub specular: Option<Handle<Image>>,
+use crate::types::{TERRAIN_LAYERS, TileType};
+
+pub type TerrainMaterial = ExtendedMaterial<StandardMaterial, TerrainBlendExtension>;
+
+pub struct TerrainMaterialPlugin;
+
+impl Plugin for TerrainMaterialPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(MaterialPlugin::<TerrainMaterial>::default());
+    }
 }
 
-/// Load a terrain material and keep the individual texture handles around so they can be
-/// reused for things like UI previews.
-pub fn load_terrain_material(
-    asset_server: &AssetServer,
-    materials: &mut Assets<StandardMaterial>,
-    base_color: String,
-    normal: Option<String>,
-    roughness: Option<String>,
-    specular: Option<String>,
-) -> TerrainMaterialHandles {
-    let base_color_handle: Handle<Image> = asset_server.load(base_color);
-    let normal_handle: Option<Handle<Image>> = normal.map(|path| asset_server.load(path));
-    let roughness_handle: Option<Handle<Image>> = roughness.map(|path| asset_server.load(path));
-    let specular_handle: Option<Handle<Image>> = specular.map(|path| asset_server.load(path));
+#[derive(Clone, Copy, Debug, ShaderType)]
+pub struct TerrainBlendParams {
+    pub uv_scale: f32,
+    pub inv_map_width: f32,
+    pub inv_map_height: f32,
+    pub _padding: f32,
+    pub layer_tints: [Vec4; TERRAIN_LAYERS.len()],
+}
 
-    let mut material = StandardMaterial {
-        base_color_texture: Some(base_color_handle.clone()),
-        normal_map_texture: normal_handle.clone(),
-        metallic_roughness_texture: specular_handle.clone(),
-        occlusion_texture: roughness_handle.clone(),
-        ..default()
-    };
+#[derive(Asset, AsBindGroup, Clone, Debug, TypePath)]
+pub struct TerrainBlendExtension {
+    #[uniform(100)]
+    pub params: TerrainBlendParams,
+    #[texture(101)]
+    #[sampler(102)]
+    pub splatmap: Handle<Image>,
+    #[texture(103)]
+    #[sampler(104)]
+    pub layer0: Handle<Image>,
+    #[texture(105)]
+    #[sampler(106)]
+    pub layer1: Handle<Image>,
+    #[texture(107)]
+    #[sampler(108)]
+    pub layer2: Handle<Image>,
+    #[texture(109)]
+    #[sampler(110)]
+    pub layer3: Handle<Image>,
+}
 
-    material.perceptual_roughness = 1.0;
-    material.metallic = 0.0;
+impl TerrainBlendExtension {
+    pub fn set_layer_handles(&mut self, handles: &[Handle<Image>; TERRAIN_LAYERS.len()]) {
+        self.layer0 = handles[0].clone();
+        self.layer1 = handles[1].clone();
+        self.layer2 = handles[2].clone();
+        self.layer3 = handles[3].clone();
+    }
+}
 
-    let material_handle = materials.add(material);
+impl MaterialExtension for TerrainBlendExtension {
+    fn fragment_shader() -> ShaderRef {
+        ShaderRef::Path("shaders/terrain_blend_extension.wgsl".into())
+    }
 
-    TerrainMaterialHandles {
-        material: material_handle,
-        base_color: base_color_handle,
-        normal: normal_handle,
-        roughness: roughness_handle,
-        specular: specular_handle,
+    fn deferred_fragment_shader() -> ShaderRef {
+        ShaderRef::Path("shaders/terrain_blend_extension.wgsl".into())
     }
 }

--- a/src/texture/material.rs
+++ b/src/texture/material.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use bevy::reflect::TypePath;
 use bevy::render::render_resource::{AsBindGroup, ShaderRef, ShaderType};
 
-use crate::types::{TERRAIN_LAYERS, TileType};
+use crate::types::TERRAIN_LAYERS;
 
 pub type TerrainMaterial = ExtendedMaterial<StandardMaterial, TerrainBlendExtension>;
 

--- a/src/texture/material.rs
+++ b/src/texture/material.rs
@@ -30,17 +30,17 @@ pub struct TerrainBlendParams {
 pub struct TerrainBlendExtension {
     #[uniform(100)]
     pub params: TerrainBlendParams,
-    #[texture(101, sampler = "splatmap_sampler")]
+    #[texture(101)]
     pub splatmap: Handle<Image>,
     #[sampler(102)]
     pub splatmap_sampler: ImageSampler,
-    #[texture(103, sampler = "layer_sampler")]
+    #[texture(103)]
     pub layer0: Handle<Image>,
-    #[texture(104, sampler = "layer_sampler")]
+    #[texture(104)]
     pub layer1: Handle<Image>,
-    #[texture(105, sampler = "layer_sampler")]
+    #[texture(105)]
     pub layer2: Handle<Image>,
-    #[texture(106, sampler = "layer_sampler")]
+    #[texture(106)]
     pub layer3: Handle<Image>,
     #[sampler(107)]
     pub layer_sampler: ImageSampler,

--- a/src/texture/material.rs
+++ b/src/texture/material.rs
@@ -3,6 +3,7 @@ use bevy::pbr::{ExtendedMaterial, MaterialExtension, MaterialPlugin};
 use bevy::prelude::*;
 use bevy::reflect::TypePath;
 use bevy::render::render_resource::{AsBindGroup, ShaderRef, ShaderType};
+use bevy::render::texture::ImageSampler;
 
 use crate::types::TERRAIN_LAYERS;
 
@@ -29,21 +30,20 @@ pub struct TerrainBlendParams {
 pub struct TerrainBlendExtension {
     #[uniform(100)]
     pub params: TerrainBlendParams,
-    #[texture(101)]
-    #[sampler(102)]
+    #[texture(101, sampler = "splatmap_sampler")]
     pub splatmap: Handle<Image>,
-    #[texture(103)]
-    #[sampler(104)]
+    #[sampler(102)]
+    pub splatmap_sampler: ImageSampler,
+    #[texture(103, sampler = "layer_sampler")]
     pub layer0: Handle<Image>,
-    #[texture(105)]
-    #[sampler(106)]
+    #[texture(104, sampler = "layer_sampler")]
     pub layer1: Handle<Image>,
-    #[texture(107)]
-    #[sampler(108)]
+    #[texture(105, sampler = "layer_sampler")]
     pub layer2: Handle<Image>,
-    #[texture(109)]
-    #[sampler(110)]
+    #[texture(106, sampler = "layer_sampler")]
     pub layer3: Handle<Image>,
+    #[sampler(107)]
+    pub layer_sampler: ImageSampler,
 }
 
 impl TerrainBlendExtension {

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -7,6 +7,7 @@ pub struct TexturePlugin;
 
 impl Plugin for TexturePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<registry::TerrainTextureRegistry>();
+        app.init_resource::<registry::TerrainTextureRegistry>()
+            .add_plugins(material::TerrainMaterialPlugin);
     }
 }

--- a/src/texture/registry.rs
+++ b/src/texture/registry.rs
@@ -36,7 +36,7 @@ impl TerrainTextureRegistry {
         tile_type: TileType,
         name: impl Into<String>,
         asset_server: &AssetServer,
-        base_color: &str,
+        base_color: &'static str,
         tint: Color,
     ) -> Handle<Image> {
         let base_color_handle: Handle<Image> = asset_server.load(base_color);
@@ -90,7 +90,13 @@ impl TerrainTextureRegistry {
         for (index, layer) in TERRAIN_LAYERS.iter().enumerate() {
             if let Some(entry) = self.get(*layer) {
                 handles[index] = entry.base_color.clone();
-                tints[index] = Vec4::from_array(entry.tint.as_linear_rgba_f32());
+                let tint_linear = entry.tint.to_linear();
+                tints[index] = Vec4::new(
+                    tint_linear.red,
+                    tint_linear.green,
+                    tint_linear.blue,
+                    tint_linear.alpha,
+                );
             }
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -56,6 +56,13 @@ impl Default for TileType {
     }
 }
 
+pub const TERRAIN_LAYERS: [TileType; 4] = [
+    TileType::Grass,
+    TileType::Dirt,
+    TileType::Cliff,
+    TileType::Water,
+];
+
 #[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode)]
 pub struct Tile {
     pub kind: TileKind,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -89,7 +89,7 @@ fn ui_panel(
             ui.separator();
             ui.collapsing("Textures", |ui| {
                 const COLUMNS: usize = 4;
-                let mut grid = egui::Grid::new("texture_palette_grid")
+                let grid = egui::Grid::new("texture_palette_grid")
                     .spacing([6.0, 6.0])
                     .num_columns(COLUMNS);
 
@@ -115,11 +115,9 @@ fn ui_panel(
                                 });
                             });
 
-                        let mut response = inner.response;
+                        let response = inner.response.on_hover_text(item.name.clone());
 
-                        let response2 = response.on_hover_text(item.name.clone());
-
-                        if response2.clicked() {
+                        if response.clicked() {
                             state.current_texture = item.tile_type;
                         }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -66,6 +66,14 @@ fn ui_panel(
             }
 
             ui.separator();
+            let texture_slider = egui::Slider::new(&mut state.uv_scale, 0.5..=16.0)
+                .logarithmic(true)
+                .text("Texture Scale");
+            if ui.add(texture_slider).changed() {
+                state.map_dirty = true;
+            }
+
+            ui.separator();
             if ui.button("Save").clicked() {
                 save_map("map.json", &state.map).ok();
             }


### PR DESCRIPTION
## Summary
- replace per-tile materials with a custom extended material that blends four terrain layers via a splatmap
- generate world-space UVs and a splatmap image when rebuilding the terrain mesh, and configure repeat samplers for terrain textures
- expose a texture scale control in the editor UI and add a WGSL fragment shader that handles the new blending workflow

## Testing
- `cargo fmt`
- `cargo check` *(fails: missing system library `alsa` required by `alsa-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68d95dca61ac833293845babd6659272