### PR TITLE
Make texture palette tiles clickable

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -227,13 +227,11 @@ fn paint_tiles(
                 None
             };
 
-            let tile_type = current.tile_type.clone();
             if current.kind != kind
                 || current.elevation != elevation
                 || current.ramp_direction != target_ramp_direction
                 || current.tile_type != tile_type
             {
-                let tile_type = current.tile_type.clone();
                 state_ref.map.set(
                     x,
                     y,

--- a/src/texture/registry.rs
+++ b/src/texture/registry.rs
@@ -52,7 +52,7 @@ impl TerrainTextureRegistry {
             base_color.to_string(),
             normal.map(|s| s.to_string()),
             roughness.map(|s| s.to_string()),
-            specular.map(|s| s.to_string())
+            specular.map(|s| s.to_string()),
         );
 
         self.register_loaded(TerrainTextureEntry {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -94,24 +94,27 @@ fn ui_panel(
                             egui::Stroke::NONE
                         };
 
-                        let inner = egui::Frame::none()
+                        let response = egui::Frame::none()
                             .inner_margin(egui::Margin::same(2.0))
                             .stroke(stroke)
                             .show(grid_ui, |ui| {
                                 ui.set_min_size(egui::Vec2::splat(36.0));
                                 ui.centered_and_justified(|ui| {
-                                    ui.add(egui::Image::new(egui::load::SizedTexture {
-                                        id: item.texture,
-                                        size: egui::vec2(32.0, 32.0),
-                                    }));
-                                });
-                            });
+                                    ui.add(
+                                        egui::ImageButton::new(egui::load::SizedTexture {
+                                            id: item.texture,
+                                            size: egui::vec2(32.0, 32.0),
+                                        })
+                                        .frame(false),
+                                    )
+                                })
+                                .inner
+                            })
+                            .inner;
 
-                        let mut response = inner.response;
+                        let response = response.on_hover_text(item.name.clone());
 
-                        let response2 = response.on_hover_text(item.name.clone());
-
-                        if response2.clicked() {
+                        if response.clicked() {
                             state.current_texture = item.tile_type;
                         }
 


### PR DESCRIPTION
## Summary
- wrap each palette icon in an `ImageButton` so the texture selection responds to clicks
- retain the highlighted frame styling while ensuring hover text and selection work

## Testing
- `cargo fmt`
- `cargo check` *(fails: missing system library `alsa` required by alsa-sys build script)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c696d9c08332a6cd004c721626c1