### PR TITLE
Switch terrain textures to world-space UVs

### DIFF
--- a/assets/shaders/terrain_world_uv.wgsl
+++ b/assets/shaders/terrain_world_uv.wgsl
@@ -1,0 +1,122 @@
+#import bevy_pbr::{
+    mesh_functions,
+    skinning,
+    morph::morph,
+    forward_io::{Vertex, VertexOutput},
+    view_transformations::position_world_to_clip,
+};
+
+struct TerrainMaterialParams {
+    tiles_per_texture: f32,
+    _padding: vec3<f32>,
+}
+
+@group(2) @binding(15)
+var<uniform> terrain_params: TerrainMaterialParams;
+
+#ifdef MORPH_TARGETS
+fn morph_vertex(vertex_in: Vertex) -> Vertex {
+    var vertex = vertex_in;
+    let weight_count = bevy_pbr::morph::layer_count();
+    for (var i: u32 = 0u; i < weight_count; i ++) {
+        let weight = bevy_pbr::morph::weight_at(i);
+        if weight == 0.0 {
+            continue;
+        }
+        vertex.position += weight * morph(vertex.index, bevy_pbr::morph::position_offset, i);
+#ifdef VERTEX_NORMALS
+        vertex.normal += weight * morph(vertex.index, bevy_pbr::morph::normal_offset, i);
+#endif
+#ifdef VERTEX_TANGENTS
+        vertex.tangent += vec4(weight * morph(vertex.index, bevy_pbr::morph::tangent_offset, i), 0.0);
+#endif
+    }
+    return vertex;
+}
+#endif
+
+@vertex
+fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
+    var out: VertexOutput;
+
+#ifdef MORPH_TARGETS
+    var vertex = morph_vertex(vertex_no_morph);
+#else
+    var vertex = vertex_no_morph;
+#endif
+
+#ifdef SKINNED
+    var world_from_local = skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
+#else
+    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416 .
+    var world_from_local = mesh_functions::get_world_from_local(vertex_no_morph.instance_index);
+#endif
+
+#ifdef VERTEX_NORMALS
+#ifdef SKINNED
+    out.world_normal = skinning::skin_normals(world_from_local, vertex.normal);
+#else
+    out.world_normal = mesh_functions::mesh_normal_local_to_world(
+        vertex.normal,
+        // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+        // See https://github.com/gfx-rs/naga/issues/2416
+        vertex_no_morph.instance_index
+    );
+#endif
+#endif
+
+#ifdef VERTEX_POSITIONS
+    out.world_position = mesh_functions::mesh_position_local_to_world(world_from_local, vec4<f32>(vertex.position, 1.0));
+    out.position = position_world_to_clip(out.world_position.xyz);
+#endif
+
+#if defined(VERTEX_UVS_A) || defined(VERTEX_UVS_B)
+    let scale = max(terrain_params.tiles_per_texture, 0.0001);
+    let inv_scale = 1.0 / scale;
+#endif
+#ifdef VERTEX_UVS_A
+    out.uv = out.world_position.xz * inv_scale;
+#endif
+#ifdef VERTEX_UVS_B
+    out.uv_b = out.world_position.xz * inv_scale;
+#endif
+
+#ifdef VERTEX_TANGENTS
+    out.world_tangent = mesh_functions::mesh_tangent_local_to_world(
+        world_from_local,
+        vertex.tangent,
+        // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+        // See https://github.com/gfx-rs/naga/issues/2416
+        vertex_no_morph.instance_index
+    );
+#endif
+
+#ifdef VERTEX_COLORS
+    out.color = vertex.color;
+#endif
+
+#ifdef VERTEX_OUTPUT_INSTANCE_INDEX
+    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416
+    out.instance_index = vertex_no_morph.instance_index;
+#endif
+
+#ifdef VISIBILITY_RANGE_DITHER
+    out.visibility_range_dither = mesh_functions::get_visibility_range_dither_level(
+        vertex_no_morph.instance_index, world_from_local[3]);
+#endif
+
+    return out;
+}
+
+@fragment
+fn fragment(
+    mesh: VertexOutput,
+) -> @location(0) vec4<f32> {
+#ifdef VERTEX_COLORS
+    return mesh.color;
+#else
+    return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+#endif
+}

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,6 +1,8 @@
 use crate::terrain;
+use crate::texture::material::{TerrainMaterial, TerrainMaterialSettings};
 use crate::texture::registry::TerrainTextureRegistry;
 use crate::types::*;
+use bevy::pbr::MaterialMeshBundle;
 use bevy::prelude::*;
 use bevy_egui::EguiContexts;
 
@@ -83,16 +85,18 @@ fn configure_hover_gizmos(mut configs: ResMut<GizmoConfigStore>) {
 
 fn spawn_editor_assets(
     mut commands: Commands,
-    mut mats: ResMut<Assets<StandardMaterial>>,
+    mut mats: ResMut<Assets<TerrainMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
     asset_server: Res<AssetServer>,
     mut textures: ResMut<TerrainTextureRegistry>,
+    settings: Res<TerrainMaterialSettings>,
 ) {
     textures.load_and_register(
         TileType::Grass,
         "Rocky Terrain",
         &asset_server,
         &mut mats,
+        &settings,
         "textures/terrain/rocky_terrain_02_diff_1k.png",
         Some("textures/terrain/rocky_terrain_02_nor_gl_1k_fixed.exr"),
         // Some("textures/terrain/rocky_terrain_02_rough_1k.exr"),
@@ -106,6 +110,7 @@ fn spawn_editor_assets(
         "Ground Rock",
         &asset_server,
         &mut mats,
+        &settings,
         "textures/terrain/rock/aerial_ground_rock_diff_1k.png",
         Some("textures/terrain/rock/aerial_ground_rock_nor_gl_1k_fixed.exr"),
         Some("textures/terrain/rock/aerial_ground_rock_rough_1k.png"),
@@ -118,7 +123,7 @@ fn spawn_editor_assets(
     for entry in textures.iter() {
         let mesh = meshes.add(terrain::empty_mesh());
         let entity = commands
-            .spawn(PbrBundle {
+            .spawn(MaterialMeshBundle::<TerrainMaterial> {
                 mesh: mesh.clone(),
                 material: entry.material.clone(),
                 transform: Transform::default(),

--- a/src/texture/material.rs
+++ b/src/texture/material.rs
@@ -1,8 +1,63 @@
+use bevy::math::Vec3;
+use bevy::pbr::{ExtendedMaterial, MaterialExtension, StandardMaterial};
 use bevy::prelude::*;
+use bevy::render::render_resource::{ShaderRef, ShaderType};
+
+pub const DEFAULT_TILES_PER_TEXTURE: f32 = 4.0;
+
+#[derive(AsBindGroup, Asset, TypePath, Debug, Clone)]
+pub struct TerrainMaterialExtension {
+    #[uniform(15)]
+    pub params: TerrainMaterialUniform,
+}
+
+#[derive(Clone, Copy, Debug, ShaderType)]
+pub struct TerrainMaterialUniform {
+    pub tiles_per_texture: f32,
+    pub _padding: Vec3,
+}
+
+impl Default for TerrainMaterialExtension {
+    fn default() -> Self {
+        Self {
+            params: TerrainMaterialUniform {
+                tiles_per_texture: DEFAULT_TILES_PER_TEXTURE,
+                _padding: Vec3::ZERO,
+            },
+        }
+    }
+}
+
+impl TerrainMaterialExtension {
+    pub fn set_tiles_per_texture(&mut self, tiles_per_texture: f32) {
+        self.params.tiles_per_texture = tiles_per_texture.max(0.0001);
+    }
+}
+
+impl MaterialExtension for TerrainMaterialExtension {
+    fn vertex_shader() -> ShaderRef {
+        ShaderRef::Path("shaders/terrain_world_uv.wgsl".into())
+    }
+}
+
+pub type TerrainMaterial = ExtendedMaterial<StandardMaterial, TerrainMaterialExtension>;
+
+#[derive(Resource, Debug, Clone)]
+pub struct TerrainMaterialSettings {
+    pub tiles_per_texture: f32,
+}
+
+impl Default for TerrainMaterialSettings {
+    fn default() -> Self {
+        Self {
+            tiles_per_texture: DEFAULT_TILES_PER_TEXTURE,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct TerrainMaterialHandles {
-    pub material: Handle<StandardMaterial>,
+    pub material: Handle<TerrainMaterial>,
     pub base_color: Handle<Image>,
     pub normal: Option<Handle<Image>>,
     pub roughness: Option<Handle<Image>>,
@@ -13,7 +68,8 @@ pub struct TerrainMaterialHandles {
 /// reused for things like UI previews.
 pub fn load_terrain_material(
     asset_server: &AssetServer,
-    materials: &mut Assets<StandardMaterial>,
+    materials: &mut Assets<TerrainMaterial>,
+    settings: &TerrainMaterialSettings,
     base_color: String,
     normal: Option<String>,
     roughness: Option<String>,
@@ -24,7 +80,7 @@ pub fn load_terrain_material(
     let roughness_handle: Option<Handle<Image>> = roughness.map(|path| asset_server.load(path));
     let specular_handle: Option<Handle<Image>> = specular.map(|path| asset_server.load(path));
 
-    let mut material = StandardMaterial {
+    let mut base_material = StandardMaterial {
         base_color_texture: Some(base_color_handle.clone()),
         normal_map_texture: normal_handle.clone(),
         metallic_roughness_texture: specular_handle.clone(),
@@ -32,10 +88,16 @@ pub fn load_terrain_material(
         ..default()
     };
 
-    material.perceptual_roughness = 1.0;
-    material.metallic = 0.0;
+    base_material.perceptual_roughness = 1.0;
+    base_material.metallic = 0.0;
 
-    let material_handle = materials.add(material);
+    let mut extension = TerrainMaterialExtension::default();
+    extension.set_tiles_per_texture(settings.tiles_per_texture);
+
+    let material_handle = materials.add(TerrainMaterial {
+        base: base_material,
+        extension,
+    });
 
     TerrainMaterialHandles {
         material: material_handle,

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1,3 +1,4 @@
+use bevy::pbr::MaterialPlugin;
 use bevy::prelude::*;
 
 pub mod material;
@@ -7,6 +8,8 @@ pub struct TexturePlugin;
 
 impl Plugin for TexturePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<registry::TerrainTextureRegistry>();
+        app.add_plugins(MaterialPlugin::<material::TerrainMaterial>::default())
+            .init_resource::<material::TerrainMaterialSettings>()
+            .init_resource::<registry::TerrainTextureRegistry>();
     }
 }

--- a/src/texture/registry.rs
+++ b/src/texture/registry.rs
@@ -4,14 +4,14 @@ use bevy::prelude::*;
 
 use crate::types::TileType;
 
-use super::material::{self, TerrainMaterialHandles};
+use super::material::{self, TerrainMaterial, TerrainMaterialHandles, TerrainMaterialSettings};
 
 #[derive(Debug, Clone)]
 pub struct TerrainTextureEntry {
     pub tile_type: TileType,
     pub name: String,
     pub icon: Handle<Image>,
-    pub material: Handle<StandardMaterial>,
+    pub material: Handle<TerrainMaterial>,
 }
 
 #[derive(Resource, Default)]
@@ -36,12 +36,13 @@ impl TerrainTextureRegistry {
         tile_type: TileType,
         name: impl Into<String>,
         asset_server: &AssetServer,
-        materials: &mut Assets<StandardMaterial>,
+        materials: &mut Assets<TerrainMaterial>,
+        settings: &TerrainMaterialSettings,
         base_color: &str,
         normal: Option<&str>,
         roughness: Option<&str>,
         specular: Option<&str>,
-    ) -> Handle<StandardMaterial> {
+    ) -> Handle<TerrainMaterial> {
         let TerrainMaterialHandles {
             material,
             base_color: icon,
@@ -49,6 +50,7 @@ impl TerrainTextureRegistry {
         } = material::load_terrain_material(
             asset_server,
             materials,
+            settings,
             base_color.to_string(),
             normal.map(|s| s.to_string()),
             roughness.map(|s| s.to_string()),
@@ -63,6 +65,18 @@ impl TerrainTextureRegistry {
         });
 
         material
+    }
+
+    pub fn update_tiles_per_texture(
+        &self,
+        materials: &mut Assets<TerrainMaterial>,
+        tiles_per_texture: f32,
+    ) {
+        for entry in &self.entries {
+            if let Some(material) = materials.get_mut(&entry.material) {
+                material.extension.set_tiles_per_texture(tiles_per_texture);
+            }
+        }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &TerrainTextureEntry> {


### PR DESCRIPTION
## Summary
- introduce a terrain material extension that feeds a custom vertex shader computing world-space UVs
- add a configurable tiles_per_texture uniform and settings plumbing for terrain texture assets
- update the editor to spawn terrain meshes with the new material and register the supporting shader

## Testing
- cargo check *(fails: missing system library `alsa` required by bevy audio)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e253c14c833297ab2f211fd52d21