### PR TITLE
Fix rock terrain material alpha handling

### DIFF
--- a/assets/shaders/terrain_pbr_extension.wgsl
+++ b/assets/shaders/terrain_pbr_extension.wgsl
@@ -92,14 +92,15 @@ fn fragment(
     }
 
     // Sample base color using world-space planar UVs
-    let world_base = triplanar_sample(
+    var world_base = triplanar_sample(
         pbr_bindings::base_color_texture,
         pbr_bindings::base_color_sampler,
         pbr_input.world_position.xyz,
         pbr_input.world_normal.xyz,
         terrain_material_extension.uv_scale,
     );
-    pbr_input.material.base_color = alpha_discard(pbr_input.material, world_base);
+    world_base.a = 1.0;
+    pbr_input.material.base_color = world_base;
 
 //    // Alpha discard + lighting as before
 //    pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);

--- a/src/texture/material.rs
+++ b/src/texture/material.rs
@@ -72,6 +72,7 @@ pub fn load_terrain_material(
 
     base_material.perceptual_roughness = 1.0;
     base_material.metallic = 0.0;
+    base_material.alpha_mode = AlphaMode::Opaque;
 
     let material_handle = materials.add(TerrainMaterial {
         base: base_material,


### PR DESCRIPTION
## Summary
- force terrain materials to use opaque alpha mode so terrain textures are not treated as transparent
- ignore alpha from triplanar sampled textures to prevent accidental fragment discards

## Testing
- `cargo fmt`
- `cargo check` *(fails: missing system library `alsa`)*

------
https://chatgpt.com/codex/tasks/task_e_68dab803e328833297153722dbe91f22