### PR TITLE
Ensure terrain triplanar color stays opaque

### DIFF
--- a/assets/shaders/terrain_pbr_extension.wgsl
+++ b/assets/shaders/terrain_pbr_extension.wgsl
@@ -92,13 +92,14 @@ fn fragment(
     }
 
     // Sample base color using world-space planar UVs
-    let world_base = triplanar_sample(
+    var world_base = triplanar_sample(
         pbr_bindings::base_color_texture,
         pbr_bindings::base_color_sampler,
         pbr_input.world_position.xyz,
         pbr_input.world_normal.xyz,
         terrain_material_extension.uv_scale,
     );
+    world_base.a = 1.0;
     pbr_input.material.base_color = alpha_discard(pbr_input.material, world_base);
 
 //    // Alpha discard + lighting as before


### PR DESCRIPTION
## Summary
- force the terrain triplanar base-color sample to use an opaque alpha before handing it to StandardMaterial
- prevents the rock ground texture from being discarded when the view direction changes

## Testing
- cargo check *(fails: missing system dependency `alsa` required by `alsa-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68dab803e328833297153722dbe91f22