### PR TITLE
Fix terrain shader layer sampling

### DIFF
--- a/assets/shaders/terrain_pbr_extension.wgsl
+++ b/assets/shaders/terrain_pbr_extension.wgsl
@@ -24,10 +24,19 @@
 
 struct TerrainMaterialExtension {
     uv_scale: f32,
+    layer_count: u32,
+    _padding: vec2<f32>,
 }
 
 @group(2) @binding(100)
 var<uniform> terrain_material_extension: TerrainMaterialExtension;
+
+#ifdef TERRAIN_MATERIAL_EXTENSION_TEXTURE_ARRAY
+@group(2) @binding(101)
+var terrain_texture_array: texture_2d_array<f32>;
+@group(2) @binding(102)
+var terrain_texture_sampler: sampler;
+#endif
 
 fn triplanar_sample(
     tex: texture_2d<f32>,
@@ -50,6 +59,31 @@ fn triplanar_sample(
 
     return x_tex * weights.x + y_tex * weights.y + z_tex * weights.z;
 }
+
+#ifdef TERRAIN_MATERIAL_EXTENSION_TEXTURE_ARRAY
+fn triplanar_sample_layer(
+    tex: texture_2d_array<f32>,
+    samp: sampler,
+    pos: vec3<f32>,
+    norm: vec3<f32>,
+    scale: f32,
+    layer: i32,
+) -> vec4<f32> {
+    let n = normalize(norm);
+    let weights = abs(n) / (abs(n.x) + abs(n.y) + abs(n.z));
+
+    let uv_x = fract(pos.yz * scale);
+    let uv_y = fract(pos.xz * scale);
+    let uv_z = fract(pos.xy * scale);
+
+    let layer_f = f32(layer);
+    let x_tex = textureSample(tex, samp, vec3<f32>(uv_x, layer_f));
+    let y_tex = textureSample(tex, samp, vec3<f32>(uv_y, layer_f));
+    let z_tex = textureSample(tex, samp, vec3<f32>(uv_z, layer_f));
+
+    return x_tex * weights.x + y_tex * weights.y + z_tex * weights.z;
+}
+#endif
 
 
 
@@ -76,34 +110,37 @@ fn fragment(
     var pbr_input = pbr_input_from_standard_material(in, is_front);
 
     // Choose projection by dominant world normal axis
-    let an = abs(pbr_input.N); // vec3<f32>
     let scale = terrain_material_extension.uv_scale;
-    var uv: vec2<f32>;
+    var base_color = vec4<f32>(pbr_input.material.base_color.rgb, 1.0);
 
-    if (an.y >= max(an.x, an.z)) {
-        // tops: project to XZ
-        uv = pbr_input.world_position.xz * scale;
-    } else if (an.x >= an.z) {
-        // ±X sides: project to YZ
-        uv = pbr_input.world_position.yz * scale;
-    } else {
-        // ±Z sides: project to XY
-        uv = pbr_input.world_position.xy * scale;
-    }
-
-    // Sample base color using world-space planar UVs
-    let world_base = triplanar_sample(
+#ifdef STANDARD_MATERIAL_BASE_COLOR_TEXTURE
+    base_color = triplanar_sample(
         pbr_bindings::base_color_texture,
         pbr_bindings::base_color_sampler,
         pbr_input.world_position.xyz,
         pbr_input.world_normal.xyz,
-        terrain_material_extension.uv_scale,
+        scale,
     );
-    pbr_input.material.base_color = alpha_discard(pbr_input.material, world_base);
+#endif
 
-//    // Alpha discard + lighting as before
-//    pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);
+#ifdef TERRAIN_MATERIAL_EXTENSION_TEXTURE_ARRAY
+    if (terrain_material_extension.layer_count > 0u) {
+        let max_layer = i32(terrain_material_extension.layer_count) - 1;
+        let layer_value = clamp(i32(round(in.uv_b.x)), 0, max_layer);
+        var sampled = triplanar_sample_layer(
+            terrain_texture_array,
+            terrain_texture_sampler,
+            pbr_input.world_position.xyz,
+            pbr_input.world_normal.xyz,
+            scale,
+            layer_value,
+        );
+        sampled.a = 1.0;
+        base_color = sampled;
+    }
+#endif
 
+    pbr_input.material.base_color = alpha_discard(pbr_input.material, base_color);
 
 #ifdef PREPASS_PIPELINE
     let out = deferred_output(in, pbr_input);

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,7 +1,5 @@
 use crate::types::TileMap;
 use bincode::{config, decode_from_slice, encode_to_vec};
-use serde::{Deserialize, Serialize};
-
 const KEY: u8 = 0xAA;
 
 fn obfuscate(data: &mut [u8]) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod controls;
 mod editor;
 mod grid_visual;
 mod io;
+mod runtime;
 mod terrain;
 mod texture;
 mod types;
@@ -13,17 +14,23 @@ use bevy_egui::EguiPlugin;
 use camera::CameraPlugin;
 use controls::ControlsPlugin;
 use editor::EditorPlugin;
+use runtime::RuntimePlugin;
 use texture::TexturePlugin;
 use ui::UiPlugin;
 
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, EguiPlugin))
+        .configure_sets(
+            Update,
+            terrain::TerrainMeshSet::Rebuild.before(terrain::TerrainMeshSet::Cleanup),
+        )
         .add_plugins((
             TexturePlugin,
             CameraPlugin,
             ControlsPlugin,
             EditorPlugin,
+            RuntimePlugin,
             UiPlugin,
         ))
         .add_systems(Startup, setup_light)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,162 @@
+use crate::editor::EditorState;
+use crate::terrain::{self, TerrainMeshSet};
+use crate::texture::material::{self, TerrainMaterial};
+use crate::texture::registry::TerrainTextureRegistry;
+use crate::types::TileType;
+use bevy::asset::LoadState;
+use bevy::pbr::MaterialMeshBundle;
+use bevy::prelude::*;
+
+pub struct RuntimePlugin;
+
+impl Plugin for RuntimePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, setup_runtime_mesh).add_systems(
+            Update,
+            (
+                rebuild_runtime_mesh.in_set(TerrainMeshSet::Rebuild),
+                update_runtime_material.in_set(TerrainMeshSet::Rebuild),
+            ),
+        );
+    }
+}
+
+#[derive(Resource)]
+pub struct RuntimeTerrainVisual {
+    pub mesh: Handle<Mesh>,
+    pub material: Handle<TerrainMaterial>,
+    pub entity: Entity,
+}
+
+fn setup_runtime_mesh(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<TerrainMaterial>>,
+) {
+    let mesh = meshes.add(terrain::empty_mesh());
+    let material = material::create_runtime_material(&mut materials);
+    let entity = commands
+        .spawn((
+            MaterialMeshBundle {
+                mesh: mesh.clone(),
+                material: material.clone(),
+                transform: Transform::default(),
+                visibility: Visibility::Visible,
+                ..default()
+            },
+            Name::new("RuntimeTerrain"),
+        ))
+        .id();
+
+    commands.insert_resource(RuntimeTerrainVisual {
+        mesh,
+        material,
+        entity,
+    });
+}
+
+fn rebuild_runtime_mesh(
+    state: Res<EditorState>,
+    runtime: Option<Res<RuntimeTerrainVisual>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    if !state.map_dirty {
+        return;
+    }
+
+    let Some(runtime) = runtime else {
+        return;
+    };
+
+    let combined = terrain::build_combined_mesh(&state.map);
+
+    if let Some(existing) = meshes.get_mut(&runtime.mesh) {
+        *existing = combined;
+    }
+}
+
+fn update_runtime_material(
+    mut textures: ResMut<TerrainTextureRegistry>,
+    mut images: ResMut<Assets<Image>>,
+    mut materials: ResMut<Assets<TerrainMaterial>>,
+    asset_server: Res<AssetServer>,
+    runtime: Option<Res<RuntimeTerrainVisual>>,
+    mut visibility_query: Query<&mut Visibility>,
+) {
+    let Some(runtime) = runtime else {
+        return;
+    };
+
+    let Ok(mut visibility) = visibility_query.get_mut(runtime.entity) else {
+        return;
+    };
+
+    let mut waiting_for_textures = false;
+    let mut encountered_failure = false;
+
+    {
+        let registry = textures.as_ref();
+        for entry in registry.iter() {
+            match asset_server.get_load_state(entry.preview.id()) {
+                Some(LoadState::Loaded) => {}
+                Some(LoadState::Failed) => {
+                    error!(
+                        tile_type = ?entry.tile_type,
+                        "Terrain preview texture failed to load"
+                    );
+                    encountered_failure = true;
+                }
+                _ => {
+                    waiting_for_textures = true;
+                }
+            }
+        }
+    }
+
+    if encountered_failure {
+        *visibility = Visibility::Hidden;
+        return;
+    }
+
+    if waiting_for_textures {
+        *visibility = Visibility::Hidden;
+        return;
+    }
+
+    let Some(material) = materials.get_mut(&runtime.material) else {
+        *visibility = Visibility::Hidden;
+        return;
+    };
+
+    let Some(array_handle) = textures.ensure_texture_array(&mut images) else {
+        error!("Failed to assemble terrain texture array after previews loaded");
+        *visibility = Visibility::Hidden;
+        return;
+    };
+
+    let desired_layers = images
+        .get(&array_handle)
+        .map(|image| image.texture_descriptor.size.depth_or_array_layers)
+        .unwrap_or(0);
+
+    if desired_layers == 0 {
+        *visibility = Visibility::Hidden;
+        return;
+    }
+
+    if material.extension.params.layer_count != desired_layers {
+        material.extension.params.layer_count = desired_layers;
+    }
+
+    if material
+        .extension
+        .texture_array
+        .as_ref()
+        .map(|handle| handle != &array_handle)
+        .unwrap_or(true)
+    {
+        material.extension.texture_array = Some(array_handle.clone());
+    }
+
+    *visibility = Visibility::Visible;
+}

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::types::{RampDirection, TILE_HEIGHT, TILE_SIZE, TileKind, TileMap, TileType};
+use bevy::ecs::schedule::SystemSet;
 use bevy::prelude::*;
 use bevy::render::mesh::Indices;
 use bevy::render::render_asset::RenderAssetUsages;
@@ -10,6 +11,12 @@ pub const CORNER_NW: usize = 0;
 pub const CORNER_NE: usize = 1;
 pub const CORNER_SW: usize = 2;
 pub const CORNER_SE: usize = 3;
+
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub enum TerrainMeshSet {
+    Rebuild,
+    Cleanup,
+}
 
 pub fn tile_corner_heights(map: &TileMap, x: u32, y: u32) -> [f32; 4] {
     let tile = map.get(x, y);
@@ -58,10 +65,27 @@ pub fn empty_mesh() -> Mesh {
 }
 
 pub fn build_map_meshes(map: &TileMap) -> HashMap<TileType, Mesh> {
-    let mut result = HashMap::new();
+    let mut buffers: HashMap<TileType, MeshBuffers> = HashMap::new();
+    populate_mesh_buffers(map, Some(&mut buffers), None);
+    buffers
+        .into_iter()
+        .map(|(tile_type, buffer)| (tile_type, buffer.into_mesh()))
+        .collect()
+}
 
+pub fn build_combined_mesh(map: &TileMap) -> Mesh {
+    let mut buffer = MeshBuffers::with_tile_types();
+    populate_mesh_buffers(map, None, Some(&mut buffer));
+    buffer.into_mesh()
+}
+
+fn populate_mesh_buffers(
+    map: &TileMap,
+    mut per_type: Option<&mut HashMap<TileType, MeshBuffers>>,
+    mut combined: Option<&mut MeshBuffers>,
+) {
     if map.width == 0 || map.height == 0 {
-        return result;
+        return;
     }
 
     let mut corner_cache = vec![[0.0f32; 4]; (map.width * map.height) as usize];
@@ -72,90 +96,103 @@ pub fn build_map_meshes(map: &TileMap) -> HashMap<TileType, Mesh> {
         }
     }
 
-    let mut buffers: HashMap<TileType, MeshBuffers> = HashMap::new();
-
     for y in 0..map.height {
         for x in 0..map.width {
-            let idx = map.idx(x, y);
-            let tile = map.get(x, y);
-            let corners = corner_cache[idx];
-            let x0 = x as f32 * TILE_SIZE;
-            let x1 = x0 + TILE_SIZE;
-            let z0 = y as f32 * TILE_SIZE;
-            let z1 = z0 + TILE_SIZE;
+            if let Some(buffers) = per_type.as_mut() {
+                let tile_type = map.get(x, y).tile_type;
+                let buffer = buffers.entry(tile_type).or_default();
+                append_tile_geometry(map, &corner_cache, x, y, buffer, None);
+            }
 
-            let buffer = buffers.entry(tile.tile_type).or_default();
-
-            let nw = Vec3::new(x0, corners[CORNER_NW], z0);
-            let ne = Vec3::new(x1, corners[CORNER_NE], z0);
-            let sw = Vec3::new(x0, corners[CORNER_SW], z1);
-            let se = Vec3::new(x1, corners[CORNER_SE], z1);
-
-            buffer.push_quad([nw, sw, se, ne], [[0.0, 0.0]; 4]);
-
-            let (bnw, bne) = if y > 0 {
-                let neighbor = corner_cache[map.idx(x, y - 1)];
-                (neighbor[CORNER_SW], neighbor[CORNER_SE])
-            } else {
-                (0.0, 0.0)
-            };
-            buffer.add_side_face(
-                nw,
-                ne,
-                Vec3::new(x0, bnw.min(nw.y), z0),
-                Vec3::new(x1, bne.min(ne.y), z0),
-                RampDirection::North,
-            );
-
-            let (bsw, bse) = if y + 1 < map.height {
-                let neighbor = corner_cache[map.idx(x, y + 1)];
-                (neighbor[CORNER_NW], neighbor[CORNER_NE])
-            } else {
-                (0.0, 0.0)
-            };
-            buffer.add_side_face(
-                se,
-                sw,
-                Vec3::new(x1, bse.min(se.y), z1),
-                Vec3::new(x0, bsw.min(sw.y), z1),
-                RampDirection::South,
-            );
-
-            let (bnw, bsw) = if x > 0 {
-                let neighbor = corner_cache[map.idx(x - 1, y)];
-                (neighbor[CORNER_NE], neighbor[CORNER_SE])
-            } else {
-                (0.0, 0.0)
-            };
-            buffer.add_side_face(
-                sw,
-                nw,
-                Vec3::new(x0, bsw.min(sw.y), z1),
-                Vec3::new(x0, bnw.min(nw.y), z0),
-                RampDirection::West,
-            );
-
-            let (bne, bse) = if x + 1 < map.width {
-                let neighbor = corner_cache[map.idx(x + 1, y)];
-                (neighbor[CORNER_NW], neighbor[CORNER_SW])
-            } else {
-                (0.0, 0.0)
-            };
-            buffer.add_side_face(
-                ne,
-                se,
-                Vec3::new(x1, bne.min(ne.y), z0),
-                Vec3::new(x1, bse.min(se.y), z1),
-                RampDirection::East,
-            );
+            if let Some(combined_buffer) = combined.as_mut() {
+                let tile_layer = map.get(x, y).tile_type.as_index() as f32;
+                append_tile_geometry(map, &corner_cache, x, y, combined_buffer, Some(tile_layer));
+            }
         }
     }
+}
 
-    for (tile_type, buffer) in buffers {
-        result.insert(tile_type, buffer.into_mesh());
-    }
+fn append_tile_geometry(
+    map: &TileMap,
+    corner_cache: &[[f32; 4]],
+    x: u32,
+    y: u32,
+    buffer: &mut MeshBuffers,
+    tile_layer: Option<f32>,
+) {
+    let idx = map.idx(x, y);
+    let corners = corner_cache[idx];
+    let x0 = x as f32 * TILE_SIZE;
+    let x1 = x0 + TILE_SIZE;
+    let z0 = y as f32 * TILE_SIZE;
+    let z1 = z0 + TILE_SIZE;
 
-    result
+    let nw = Vec3::new(x0, corners[CORNER_NW], z0);
+    let ne = Vec3::new(x1, corners[CORNER_NE], z0);
+    let sw = Vec3::new(x0, corners[CORNER_SW], z1);
+    let se = Vec3::new(x1, corners[CORNER_SE], z1);
+
+    buffer.push_quad([nw, sw, se, ne], [[0.0, 0.0]; 4], tile_layer);
+
+    let (bnw, bne) = if y > 0 {
+        let neighbor = corner_cache[map.idx(x, y - 1)];
+        (neighbor[CORNER_SW], neighbor[CORNER_SE])
+    } else {
+        (0.0, 0.0)
+    };
+    buffer.add_side_face(
+        nw,
+        ne,
+        Vec3::new(x0, bnw.min(nw.y), z0),
+        Vec3::new(x1, bne.min(ne.y), z0),
+        RampDirection::North,
+        tile_layer,
+    );
+
+    let (bsw, bse) = if y + 1 < map.height {
+        let neighbor = corner_cache[map.idx(x, y + 1)];
+        (neighbor[CORNER_NW], neighbor[CORNER_NE])
+    } else {
+        (0.0, 0.0)
+    };
+    buffer.add_side_face(
+        se,
+        sw,
+        Vec3::new(x1, bse.min(se.y), z1),
+        Vec3::new(x0, bsw.min(sw.y), z1),
+        RampDirection::South,
+        tile_layer,
+    );
+
+    let (bnw, bsw) = if x > 0 {
+        let neighbor = corner_cache[map.idx(x - 1, y)];
+        (neighbor[CORNER_NE], neighbor[CORNER_SE])
+    } else {
+        (0.0, 0.0)
+    };
+    buffer.add_side_face(
+        sw,
+        nw,
+        Vec3::new(x0, bsw.min(sw.y), z1),
+        Vec3::new(x0, bnw.min(nw.y), z0),
+        RampDirection::West,
+        tile_layer,
+    );
+
+    let (bne, bse) = if x + 1 < map.width {
+        let neighbor = corner_cache[map.idx(x + 1, y)];
+        (neighbor[CORNER_NW], neighbor[CORNER_SW])
+    } else {
+        (0.0, 0.0)
+    };
+    buffer.add_side_face(
+        ne,
+        se,
+        Vec3::new(x1, bne.min(ne.y), z0),
+        Vec3::new(x1, bse.min(se.y), z1),
+        RampDirection::East,
+        tile_layer,
+    );
 }
 
 fn find_ramp_target(map: &TileMap, x: u32, y: u32, base: f32) -> Option<(RampDirection, f32)> {
@@ -200,20 +237,30 @@ struct MeshBuffers {
     positions: Vec<[f32; 3]>,
     normals: Vec<[f32; 3]>,
     uvs: Vec<[f32; 2]>,
+    tile_layers: Option<Vec<[f32; 2]>>,
     indices: Vec<u32>,
     next_index: u32,
 }
 
 impl MeshBuffers {
-    fn push_quad(&mut self, verts: [Vec3; 4], tex: [[f32; 2]; 4]) {
+    fn with_tile_types() -> Self {
+        Self {
+            tile_layers: Some(Vec::new()),
+            ..Default::default()
+        }
+    }
+
+    fn push_quad(&mut self, verts: [Vec3; 4], tex: [[f32; 2]; 4], tile_layer: Option<f32>) {
         push_quad(
             &mut self.positions,
             &mut self.normals,
             &mut self.uvs,
+            self.tile_layers.as_mut(),
             &mut self.indices,
             &mut self.next_index,
             verts,
             tex,
+            tile_layer,
         );
     }
 
@@ -224,11 +271,13 @@ impl MeshBuffers {
         bottom_a: Vec3,
         bottom_b: Vec3,
         direction: RampDirection,
+        tile_layer: Option<f32>,
     ) {
         add_side_face(
             &mut self.positions,
             &mut self.normals,
             &mut self.uvs,
+            self.tile_layers.as_mut(),
             &mut self.indices,
             &mut self.next_index,
             top_a,
@@ -236,6 +285,7 @@ impl MeshBuffers {
             bottom_a,
             bottom_b,
             direction,
+            tile_layer,
         );
     }
 
@@ -244,6 +294,11 @@ impl MeshBuffers {
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, self.positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, self.normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, self.uvs);
+        if let Some(layers) = self.tile_layers {
+            if !layers.is_empty() {
+                mesh.insert_attribute(Mesh::ATTRIBUTE_UV_1, layers);
+            }
+        }
         if !self.indices.is_empty() {
             mesh.insert_indices(Indices::U32(self.indices));
         }
@@ -255,10 +310,12 @@ fn push_quad(
     positions: &mut Vec<[f32; 3]>,
     normals: &mut Vec<[f32; 3]>,
     uvs: &mut Vec<[f32; 2]>,
+    tile_layers: Option<&mut Vec<[f32; 2]>>,
     indices: &mut Vec<u32>,
     next_index: &mut u32,
     verts: [Vec3; 4],
     tex: [[f32; 2]; 4],
+    tile_layer: Option<f32>,
 ) {
     push_triangle(
         positions, normals, uvs, indices, next_index, verts[0], verts[1], verts[2], tex[0], tex[1],
@@ -268,6 +325,13 @@ fn push_quad(
         positions, normals, uvs, indices, next_index, verts[0], verts[2], verts[3], tex[0], tex[2],
         tex[3],
     );
+
+    if let Some(layers) = tile_layers {
+        let value = tile_layer.unwrap_or(0.0);
+        for _ in 0..6 {
+            layers.push([value, 0.0]);
+        }
+    }
 }
 
 fn push_triangle(
@@ -301,6 +365,7 @@ fn add_side_face(
     positions: &mut Vec<[f32; 3]>,
     normals: &mut Vec<[f32; 3]>,
     uvs: &mut Vec<[f32; 2]>,
+    tile_layers: Option<&mut Vec<[f32; 2]>>,
     indices: &mut Vec<u32>,
     next_index: &mut u32,
     top_a: Vec3,
@@ -308,6 +373,7 @@ fn add_side_face(
     bottom_a: Vec3,
     bottom_b: Vec3,
     direction: RampDirection,
+    tile_layer: Option<f32>,
 ) {
     const EPS: f32 = 1e-4;
     if (top_a.y - bottom_a.y).abs() < EPS && (top_b.y - bottom_b.y).abs() < EPS {
@@ -321,5 +387,15 @@ fn add_side_face(
         RampDirection::East => ([top_a, top_b, bottom_b, bottom_a], [[0.0, 0.0]; 4]),
     };
 
-    push_quad(positions, normals, uvs, indices, next_index, verts, tex);
+    push_quad(
+        positions,
+        normals,
+        uvs,
+        tile_layers,
+        indices,
+        next_index,
+        verts,
+        tex,
+        tile_layer,
+    );
 }

--- a/src/texture/material.rs
+++ b/src/texture/material.rs
@@ -1,8 +1,14 @@
 use bevy::asset::Asset;
+use bevy::math::Vec2;
 use bevy::pbr::{ExtendedMaterial, MaterialExtension, StandardMaterial};
 use bevy::prelude::*;
 use bevy::reflect::TypePath;
-use bevy::render::render_resource::{AsBindGroup, ShaderRef};
+use bevy::render::render_asset::RenderAssetUsages;
+use bevy::render::render_resource::{
+    AsBindGroup, Extent3d, ShaderRef, ShaderType, TextureDimension, TextureFormat, TextureUsages,
+    TextureViewDescriptor, TextureViewDimension,
+};
+use bevy::render::texture::Image;
 
 use crate::types::TILE_SIZE;
 
@@ -23,16 +29,38 @@ fn default_uv_scale() -> f32 {
     1.0 / (TILE_SIZE * TILE_REPEAT)
 }
 
+#[derive(Clone, Copy, Debug, ShaderType)]
+pub struct TerrainMaterialParams {
+    pub uv_scale: f32,
+    pub layer_count: u32,
+    #[allow(dead_code)]
+    pub _padding: Vec2,
+}
+
+impl Default for TerrainMaterialParams {
+    fn default() -> Self {
+        Self {
+            uv_scale: default_uv_scale(),
+            layer_count: 0,
+            _padding: Vec2::ZERO,
+        }
+    }
+}
+
 #[derive(Asset, AsBindGroup, Debug, Clone, TypePath)]
 pub struct TerrainMaterialExtension {
     #[uniform(100)]
-    pub uv_scale: f32,
+    pub params: TerrainMaterialParams,
+    #[texture(101, dimension = "2d_array")]
+    #[sampler(102)]
+    pub texture_array: Option<Handle<Image>>,
 }
 
 impl Default for TerrainMaterialExtension {
     fn default() -> Self {
         Self {
-            uv_scale: default_uv_scale(),
+            params: TerrainMaterialParams::default(),
+            texture_array: None,
         }
     }
 }
@@ -85,4 +113,64 @@ pub fn load_terrain_material(
         roughness: roughness_handle,
         specular: specular_handle,
     }
+}
+
+pub fn create_runtime_material(materials: &mut Assets<TerrainMaterial>) -> Handle<TerrainMaterial> {
+    let base = StandardMaterial {
+        base_color_texture: None,
+        normal_map_texture: None,
+        metallic_roughness_texture: None,
+        occlusion_texture: None,
+        perceptual_roughness: 1.0,
+        metallic: 0.0,
+        ..default()
+    };
+
+    materials.add(TerrainMaterial {
+        base,
+        extension: TerrainMaterialExtension::default(),
+    })
+}
+
+pub fn create_texture_array_image(layers: &[&Image]) -> Option<Image> {
+    if layers.is_empty() {
+        return None;
+    }
+
+    let first = layers[0];
+    let size = first.texture_descriptor.size;
+    let format = first.texture_descriptor.format;
+    let layer_size = first.data.len();
+
+    if layer_size == 0 {
+        return None;
+    }
+
+    let mut data = Vec::with_capacity(layer_size * layers.len());
+    for image in layers {
+        if image.texture_descriptor.size != size || image.texture_descriptor.format != format {
+            return None;
+        }
+        data.extend_from_slice(&image.data);
+    }
+
+    let mut array_image = Image::new(
+        Extent3d {
+            width: size.width,
+            height: size.height,
+            depth_or_array_layers: layers.len() as u32,
+        },
+        TextureDimension::D2,
+        data,
+        format,
+        RenderAssetUsages::default(),
+    );
+    array_image.texture_descriptor.mip_level_count = 1;
+    array_image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST;
+    array_image.texture_view_descriptor = Some(TextureViewDescriptor {
+        dimension: Some(TextureViewDimension::D2Array),
+        ..Default::default()
+    });
+
+    Some(array_image)
 }

--- a/src/texture/registry.rs
+++ b/src/texture/registry.rs
@@ -10,7 +10,7 @@ use super::material::{self, TerrainMaterial, TerrainMaterialHandles};
 pub struct TerrainTextureEntry {
     pub tile_type: TileType,
     pub name: String,
-    pub icon: Handle<Image>,
+    pub preview: Handle<Image>,
     pub material: Handle<TerrainMaterial>,
 }
 
@@ -18,6 +18,7 @@ pub struct TerrainTextureEntry {
 pub struct TerrainTextureRegistry {
     entries: Vec<TerrainTextureEntry>,
     lookup: HashMap<TileType, usize>,
+    texture_array: Option<Handle<Image>>,
 }
 
 impl TerrainTextureRegistry {
@@ -29,6 +30,7 @@ impl TerrainTextureRegistry {
             self.lookup.insert(entry.tile_type, index);
             self.entries.push(entry);
         }
+        self.texture_array = None;
     }
 
     pub fn load_and_register(
@@ -44,7 +46,7 @@ impl TerrainTextureRegistry {
     ) -> Handle<TerrainMaterial> {
         let TerrainMaterialHandles {
             material,
-            base_color: icon,
+            base_color: preview,
             ..
         } = material::load_terrain_material(
             asset_server,
@@ -58,7 +60,7 @@ impl TerrainTextureRegistry {
         self.register_loaded(TerrainTextureEntry {
             tile_type,
             name: name.into(),
-            icon,
+            preview,
             material: material.clone(),
         });
 
@@ -73,5 +75,27 @@ impl TerrainTextureRegistry {
         self.lookup
             .get(&tile_type)
             .and_then(|index| self.entries.get(*index))
+    }
+
+    pub fn ensure_texture_array(&mut self, images: &mut Assets<Image>) -> Option<Handle<Image>> {
+        if let Some(handle) = self.texture_array.clone() {
+            if images.get(&handle).is_some() {
+                return Some(handle);
+            }
+            self.texture_array = None;
+        }
+
+        let mut layers: Vec<&Image> = Vec::with_capacity(TileType::ALL.len());
+        for tile_type in TileType::ALL {
+            let entry_index = *self.lookup.get(&tile_type)?;
+            let entry = self.entries.get(entry_index)?;
+            let image = images.get(&entry.preview)?;
+            layers.push(image);
+        }
+
+        let array_image = material::create_texture_array_image(&layers)?;
+        let handle = images.add(array_image);
+        self.texture_array = Some(handle.clone());
+        Some(handle)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,6 +50,24 @@ pub enum TileType {
     Rock,
 }
 
+impl TileType {
+    pub const ALL: [TileType; 4] = [
+        TileType::Grass,
+        TileType::Dirt,
+        TileType::Cliff,
+        TileType::Rock,
+    ];
+
+    pub fn as_index(self) -> usize {
+        match self {
+            TileType::Grass => 0,
+            TileType::Dirt => 1,
+            TileType::Cliff => 2,
+            TileType::Rock => 3,
+        }
+    }
+}
+
 impl Default for TileType {
     fn default() -> Self {
         TileType::Grass

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -23,7 +23,7 @@ fn ui_panel(
         .map(|entry| PaletteItem {
             tile_type: entry.tile_type,
             name: entry.name.clone(),
-            texture: egui_ctx.add_image(entry.icon.clone_weak()),
+            texture: egui_ctx.add_image(entry.preview.clone_weak()),
         })
         .collect();
 
@@ -81,7 +81,7 @@ fn ui_panel(
             ui.separator();
             ui.collapsing("Textures", |ui| {
                 const COLUMNS: usize = 4;
-                let mut grid = egui::Grid::new("texture_palette_grid")
+                let grid = egui::Grid::new("texture_palette_grid")
                     .spacing([6.0, 6.0])
                     .num_columns(COLUMNS);
 


### PR DESCRIPTION
## Summary
- sample the terrain texture array using the second UV set (`uv_b`) so the combined mesh reads the stored tile layer indices correctly

## Testing
- `cargo fmt`
- `cargo check` *(fails: missing system library `alsa`)*

------
https://chatgpt.com/codex/tasks/task_e_68dabd8022e48332854f1058f6b5490f