### PR TITLE
Ensure terrain texture maps use linear formats

### DIFF
--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -1,5 +1,8 @@
+use bevy::asset::AssetEvent;
+use bevy::ecs::schedule::common_conditions::on_event;
 use bevy::pbr::MaterialPlugin;
 use bevy::prelude::*;
+use bevy::render::texture::Image;
 
 pub mod material;
 pub mod registry;
@@ -9,6 +12,10 @@ pub struct TexturePlugin;
 impl Plugin for TexturePlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(MaterialPlugin::<material::TerrainMaterial>::default())
-            .init_resource::<registry::TerrainTextureRegistry>();
+            .init_resource::<registry::TerrainTextureRegistry>()
+            .add_systems(
+                Update,
+                material::format_loaded_terrain_maps.run_if(on_event::<AssetEvent<Image>>()),
+            );
     }
 }


### PR DESCRIPTION
## Summary
- add a system that watches terrain roughness and dispersion images and forces them to linear texture formats when they finish loading
- keep helper-created array and fallback images in linear space so terrain sampling is consistent
- register the system in the texture plugin so assets are fixed immediately after loading

## Testing
- cargo fmt
- cargo check *(fails: missing system library `alsa` in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc80afa2c08332850fc02fae61ed38