### PR TITLE
Add runtime splat map terrain blending

### DIFF
--- a/assets/shaders/terrain_pbr_extension.wgsl
+++ b/assets/shaders/terrain_pbr_extension.wgsl
@@ -25,6 +25,9 @@
 struct TerrainMaterialExtension {
     uv_scale: f32,
     layer_count: u32,
+    map_size: vec2<f32>,
+    tile_size: f32,
+    cliff_blend_height: f32,
     _padding: vec2<f32>,
 }
 
@@ -237,8 +240,8 @@ fn weight_component(weights: vec4<f32>, index: u32) -> f32 {
 }
 
 fn world_to_splat_uv(world_position: vec3<f32>) -> vec2<f32> {
-    let safe_tile = max(terrain_material_extension.params.tile_size, 0.0001);
-    let safe_map = max(terrain_material_extension.params.map_size, vec2<f32>(1.0, 1.0));
+    let safe_tile = max(terrain_material_extension.tile_size, 0.0001);
+    let safe_map = max(terrain_material_extension.map_size, vec2<f32>(1.0, 1.0));
     let tile_space = world_position.xz / safe_tile;
     let uv = tile_space / safe_map;
     return clamp(uv, vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 1.0));
@@ -441,7 +444,7 @@ fn fragment(
             available_layers,
         );
         let seam_height = in.uv_b.y;
-        let safe_blend = max(terrain_material_extension.params.cliff_blend_height, 0.0001);
+        let safe_blend = max(terrain_material_extension.cliff_blend_height, 0.0001);
         let delta = seam_height - pbr_input.world_position.y;
         let blend = clamp(1.0 - (delta / safe_blend), 0.0, 1.0);
 

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -492,7 +492,7 @@ pub mod splatmap {
     fn configure_image(image: &mut Image) {
         image.texture_descriptor.mip_level_count = 1;
         image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST;
-        image.sampler_descriptor = ImageSampler::Descriptor(SamplerDescriptor {
+        image.sampler = ImageSampler::Descriptor(SamplerDescriptor {
             mag_filter: FilterMode::Linear,
             min_filter: FilterMode::Linear,
             mipmap_filter: FilterMode::Nearest,

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -5,7 +5,11 @@ use bevy::ecs::schedule::SystemSet;
 use bevy::prelude::*;
 use bevy::render::mesh::Indices;
 use bevy::render::render_asset::RenderAssetUsages;
-use bevy::render::render_resource::PrimitiveTopology;
+use bevy::render::render_resource::{
+    AddressMode, FilterMode, PrimitiveTopology, SamplerDescriptor, TextureDimension, TextureFormat,
+    TextureUsages,
+};
+use bevy::render::texture::{Image, ImageSampler};
 
 pub const CORNER_NW: usize = 0;
 pub const CORNER_NE: usize = 1;
@@ -106,9 +110,9 @@ fn populate_mesh_buffers(
 
             if let Some(combined_buffer) = combined.as_mut() {
                 let tile_layer = map.get(x, y).tile_type.as_index() as f32;
-                
+
                 // dbg!(map.get(x, y).tile_type);
-                
+
                 append_tile_geometry(map, &corner_cache, x, y, combined_buffer, Some(tile_layer));
             }
         }
@@ -135,7 +139,11 @@ fn append_tile_geometry(
     let sw = Vec3::new(x0, corners[CORNER_SW], z1);
     let se = Vec3::new(x1, corners[CORNER_SE], z1);
 
-    buffer.push_quad([nw, sw, se, ne], [[0.0, 0.0]; 4], tile_layer);
+    let top_height = corners
+        .into_iter()
+        .fold(f32::NEG_INFINITY, |acc, value| acc.max(value));
+
+    buffer.push_quad([nw, sw, se, ne], [[0.0, 0.0]; 4], tile_layer, top_height);
 
     let (bnw, bne) = if y > 0 {
         let neighbor = corner_cache[map.idx(x, y - 1)];
@@ -150,6 +158,7 @@ fn append_tile_geometry(
         Vec3::new(x1, bne.min(ne.y), z0),
         RampDirection::North,
         tile_layer,
+        nw.y.max(ne.y),
     );
 
     let (bsw, bse) = if y + 1 < map.height {
@@ -165,6 +174,7 @@ fn append_tile_geometry(
         Vec3::new(x0, bsw.min(sw.y), z1),
         RampDirection::South,
         tile_layer,
+        se.y.max(sw.y),
     );
 
     let (bnw, bsw) = if x > 0 {
@@ -180,6 +190,7 @@ fn append_tile_geometry(
         Vec3::new(x0, bnw.min(nw.y), z0),
         RampDirection::West,
         tile_layer,
+        sw.y.max(nw.y),
     );
 
     let (bne, bse) = if x + 1 < map.width {
@@ -195,6 +206,7 @@ fn append_tile_geometry(
         Vec3::new(x1, bse.min(se.y), z1),
         RampDirection::East,
         tile_layer,
+        ne.y.max(se.y),
     );
 }
 
@@ -253,7 +265,13 @@ impl MeshBuffers {
         }
     }
 
-    fn push_quad(&mut self, verts: [Vec3; 4], tex: [[f32; 2]; 4], tile_layer: Option<f32>) {
+    fn push_quad(
+        &mut self,
+        verts: [Vec3; 4],
+        tex: [[f32; 2]; 4],
+        tile_layer: Option<f32>,
+        seam_height: f32,
+    ) {
         push_quad(
             &mut self.positions,
             &mut self.normals,
@@ -263,7 +281,7 @@ impl MeshBuffers {
             &mut self.next_index,
             verts,
             tex,
-            tile_layer,
+            tile_layer.map(|layer| [layer, seam_height]),
         );
     }
 
@@ -275,6 +293,7 @@ impl MeshBuffers {
         bottom_b: Vec3,
         direction: RampDirection,
         tile_layer: Option<f32>,
+        seam_height: f32,
     ) {
         add_side_face(
             &mut self.positions,
@@ -289,6 +308,7 @@ impl MeshBuffers {
             bottom_b,
             direction,
             tile_layer,
+            seam_height,
         );
     }
 
@@ -318,7 +338,7 @@ fn push_quad(
     next_index: &mut u32,
     verts: [Vec3; 4],
     tex: [[f32; 2]; 4],
-    tile_layer: Option<f32>,
+    tile_info: Option<[f32; 2]>,
 ) {
     push_triangle(
         positions, normals, uvs, indices, next_index, verts[0], verts[1], verts[2], tex[0], tex[1],
@@ -330,9 +350,8 @@ fn push_quad(
     );
 
     if let Some(layers) = tile_layers {
-        let value = tile_layer.unwrap_or(0.0);
         for _ in 0..6 {
-            layers.push([value, 0.0]);
+            layers.push(tile_info.unwrap_or([0.0, 0.0]));
         }
     }
 }
@@ -377,6 +396,7 @@ fn add_side_face(
     bottom_b: Vec3,
     direction: RampDirection,
     tile_layer: Option<f32>,
+    seam_height: f32,
 ) {
     const EPS: f32 = 1e-4;
     if (top_a.y - bottom_a.y).abs() < EPS && (top_b.y - bottom_b.y).abs() < EPS {
@@ -399,6 +419,86 @@ fn add_side_face(
         next_index,
         verts,
         tex,
-        tile_layer,
+        tile_layer.map(|layer| [layer, seam_height]),
     );
+}
+
+pub mod splatmap {
+    use super::*;
+    use bevy::render::render_asset::RenderAssetUsages;
+    use bevy::render::render_resource::Extent3d;
+
+    const CHANNELS: usize = 4;
+
+    pub fn create(map: &TileMap) -> Image {
+        let extent = extent_from_map(map);
+        let mut image = Image::new_fill(
+            extent,
+            TextureDimension::D2,
+            &[0u8; CHANNELS],
+            TextureFormat::Rgba8Unorm,
+            RenderAssetUsages::default(),
+        );
+        configure_image(&mut image);
+        write(map, &mut image);
+        image
+    }
+
+    pub fn write(map: &TileMap, image: &mut Image) {
+        let extent = extent_from_map(map);
+        if image.texture_descriptor.size != extent
+            || image.texture_descriptor.format != TextureFormat::Rgba8Unorm
+        {
+            *image = create(map);
+            return;
+        }
+
+        configure_image(image);
+
+        let width = extent.width as usize;
+        let required_len = width * (extent.height as usize) * CHANNELS;
+        if image.data.len() != required_len {
+            image.data.resize(required_len, 0);
+        }
+
+        if map.width == 0 || map.height == 0 {
+            image.data.fill(0);
+            return;
+        }
+
+        for y in 0..map.height as usize {
+            for x in 0..map.width as usize {
+                let mut pixel = [0u8; CHANNELS];
+                let tile = map.get(x as u32, y as u32);
+                let layer = tile.tile_type.as_index();
+                if layer < CHANNELS {
+                    pixel[layer] = 255;
+                }
+
+                let idx = (y * width + x) * CHANNELS;
+                image.data[idx..idx + CHANNELS].copy_from_slice(&pixel);
+            }
+        }
+    }
+
+    fn extent_from_map(map: &TileMap) -> Extent3d {
+        Extent3d {
+            width: map.width.max(1),
+            height: map.height.max(1),
+            depth_or_array_layers: 1,
+        }
+    }
+
+    fn configure_image(image: &mut Image) {
+        image.texture_descriptor.mip_level_count = 1;
+        image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST;
+        image.sampler_descriptor = ImageSampler::Descriptor(SamplerDescriptor {
+            mag_filter: FilterMode::Linear,
+            min_filter: FilterMode::Linear,
+            mipmap_filter: FilterMode::Nearest,
+            address_mode_u: AddressMode::ClampToEdge,
+            address_mode_v: AddressMode::ClampToEdge,
+            ..Default::default()
+        });
+    }
 }

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -427,6 +427,7 @@ pub mod splatmap {
     use super::*;
     use bevy::render::render_asset::RenderAssetUsages;
     use bevy::render::render_resource::Extent3d;
+    use bevy::render::texture::{ImageAddressMode, ImageFilterMode, ImageSamplerDescriptor};
 
     const CHANNELS: usize = 4;
 
@@ -492,12 +493,12 @@ pub mod splatmap {
     fn configure_image(image: &mut Image) {
         image.texture_descriptor.mip_level_count = 1;
         image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST;
-        image.sampler = ImageSampler::Descriptor(SamplerDescriptor {
-            mag_filter: FilterMode::Linear,
-            min_filter: FilterMode::Linear,
-            mipmap_filter: FilterMode::Nearest,
-            address_mode_u: AddressMode::ClampToEdge,
-            address_mode_v: AddressMode::ClampToEdge,
+        image.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+            mag_filter: ImageFilterMode::Linear,
+            min_filter: ImageFilterMode::Linear,
+            mipmap_filter: ImageFilterMode::Nearest,
+            address_mode_u: ImageAddressMode::ClampToEdge,
+            address_mode_v: ImageAddressMode::ClampToEdge,
             ..Default::default()
         });
     }


### PR DESCRIPTION
## Summary
- add per-vertex seam metadata and a splat map helper so terrain meshes can carry blend information
- generate and cache a splat map whenever the tile map changes and feed it into the runtime material
- update the terrain material params and shader to blend albedo, normals, and roughness across top surfaces and cliff seams

## Testing
- `cargo fmt`
- `cargo check` *(fails: missing system library `alsa` required by `alsa-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68e06a822ebc833289bd1afd470912e4