### PR TITLE
Add separate cliff blend ranges for floor and ceiling

### DIFF
--- a/assets/shaders/terrain_pbr_extension.wgsl
+++ b/assets/shaders/terrain_pbr_extension.wgsl
@@ -27,7 +27,8 @@ struct TerrainMaterialExtension {
     layer_count: u32,
     map_size: vec2<f32>,
     tile_size: f32,
-    cliff_blend_height: f32,
+    cliff_ceiling_blend_height: f32,
+    cliff_floor_blend_height: f32,
     _padding: vec2<f32>,
 }
 
@@ -510,9 +511,12 @@ fn fragment(
             available_layers,
         );
         let seam_height = in.uv_b.y;
-        let safe_blend = max(terrain_material_extension.cliff_blend_height, 0.0001);
+        let safe_ceiling_blend = max(
+            terrain_material_extension.cliff_ceiling_blend_height,
+            0.0001,
+        );
         let top_delta = seam_height - pbr_input.world_position.y;
-        let top_blend = clamp(1.0 - (top_delta / safe_blend), 0.0, 1.0);
+        let top_blend = clamp(1.0 - (top_delta / safe_ceiling_blend), 0.0, 1.0);
 
         var bottom_blend = 0.0;
         var bottom_layer_index = top_layer_index;
@@ -522,7 +526,11 @@ fn fragment(
             let candidate = clamp_layer_index(i32(round(in.color.r)), available_layers);
             bottom_layer_index = candidate;
             let bottom_delta = pbr_input.world_position.y - in.color.g;
-            bottom_blend = clamp(1.0 - (bottom_delta / safe_blend), 0.0, 1.0);
+            let safe_floor_blend = max(
+                terrain_material_extension.cliff_floor_blend_height,
+                0.0001,
+            );
+            bottom_blend = clamp(1.0 - (bottom_delta / safe_floor_blend), 0.0, 1.0);
             has_bottom = true;
         }
 #endif

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -266,7 +266,8 @@ fn update_runtime_material(
 
     material.extension.params.map_size = Vec2::new(splat.size.x as f32, splat.size.y as f32);
     material.extension.params.tile_size = TILE_SIZE;
-    material.extension.params.cliff_blend_height = 0.2;
+    material.extension.params.cliff_ceiling_blend_height = 0.2;
+    material.extension.params.cliff_floor_blend_height = 0.2;
 
     *visibility = Visibility::Visible;
 }

--- a/src/texture/material.rs
+++ b/src/texture/material.rs
@@ -36,7 +36,8 @@ pub struct TerrainMaterialParams {
     pub layer_count: u32,
     pub map_size: Vec2,
     pub tile_size: f32,
-    pub cliff_blend_height: f32,
+    pub cliff_ceiling_blend_height: f32,
+    pub cliff_floor_blend_height: f32,
     #[allow(dead_code)]
     pub _padding: Vec2,
 }
@@ -48,7 +49,8 @@ impl Default for TerrainMaterialParams {
             layer_count: 0,
             map_size: Vec2::splat(1.0),
             tile_size: TILE_SIZE,
-            cliff_blend_height: 0.2,
+            cliff_ceiling_blend_height: 0.2,
+            cliff_floor_blend_height: 0.2,
             _padding: Vec2::ZERO,
         }
     }


### PR DESCRIPTION
## Summary
- add independent ceiling and floor blend depths to the terrain material parameters
- update the terrain shader to mix cliff textures with the adjacent floor and same-tile ceiling using the new blend ranges
- plumb the new parameters through the runtime setup

## Testing
- cargo fmt
- cargo check *(fails: missing system library `alsa` required by `alsa-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68e17fd750b48332b5d56388b45515a9