### PR TITLE
Ensure map load triggers terrain rebuild

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,6 @@
 use crate::editor::EditorTool;
 use crate::io::{load_map, save_map};
+use crate::terrain::TerrainMeshSet;
 use crate::types::*;
 use bevy::prelude::*;
 use bevy_egui::{EguiContexts, egui};
@@ -9,7 +10,7 @@ use crate::texture::registry::TerrainTextureRegistry;
 pub struct UiPlugin;
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, ui_panel);
+        app.add_systems(Update, ui_panel.after(TerrainMeshSet::Cleanup));
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the UI system runs after the terrain cleanup systems so map loads leave the dirty flag set until the next frame

## Testing
- `cargo check` *(fails: requires system library `alsa` in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1dca127588332ad9fcfa250326ccf