### PR TITLE
Remove duplicate elevation selector from UI

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -51,12 +51,6 @@ fn ui_panel(
                 ui.label("Tile:");
                 ui.selectable_value(&mut state.current_kind, TileKind::Floor, "Floor");
                 ui.selectable_value(&mut state.current_kind, TileKind::Ramp, "Ramp");
-
-                ui.separator();
-                ui.label("Elevation:");
-                for e in 0..=3 {
-                    ui.selectable_value(&mut state.current_elev, e, format!("{e}"));
-                }
             }
 
             ui.separator();


### PR DESCRIPTION
## Summary
- remove the redundant elevation selector in the paint tool panel
- rely on the single elevation selector shared across tools

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1dd3bc8c483329cfccbaa3478bc46