### PR TITLE
Add tilemap export package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,9 +1928,11 @@ dependencies = [
  "bevy_egui",
  "bincode",
  "bytemuck",
+ "image",
  "rfd",
  "serde",
  "serde_json",
+ "zip",
 ]
 
 [[package]]
@@ -5912,6 +5914,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ anyhow = "1.0.100"
 bincode = "2.0.1"
 bytemuck = "1.23.2"  # or "ron" if you prefer
 rfd = "0.14"
+image = { version = "0.25", default-features = false, features = ["png"] }
+zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -8,6 +8,11 @@ use bevy::tasks::Task;
 use bevy_egui::EguiContexts;
 use std::path::PathBuf;
 
+pub enum ExportStatus {
+    Success(String),
+    Failure(String),
+}
+
 pub struct EditorPlugin;
 impl Plugin for EditorPlugin {
     fn build(&self, app: &mut App) {
@@ -55,6 +60,9 @@ pub struct EditorState {
     pub current_file_path: Option<PathBuf>,
     pub save_dialog_task: Option<Task<Option<PathBuf>>>,
     pub load_dialog_task: Option<Task<Option<PathBuf>>>,
+    pub export_dialog_task: Option<Task<Option<PathBuf>>>,
+    pub export_task: Option<Task<anyhow::Result<PathBuf>>>,
+    pub last_export_status: Option<ExportStatus>,
 }
 impl Default for EditorState {
     fn default() -> Self {
@@ -70,6 +78,9 @@ impl Default for EditorState {
             current_file_path: None,
             save_dialog_task: None,
             load_dialog_task: None,
+            export_dialog_task: None,
+            export_task: None,
+            last_export_status: None,
         }
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,612 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use bevy::render::mesh::{Indices, Mesh, VertexAttributeValues};
+use bevy::render::texture::Image;
+use image::ColorType;
+use image::codecs::png::PngEncoder;
+use serde::Serialize;
+use serde_json::json;
+use zip::CompressionMethod;
+use zip::write::FileOptions;
+
+use crate::terrain;
+use crate::terrain::splatmap;
+use crate::texture::registry::TerrainTextureRegistry;
+use crate::types::{TILE_SIZE, TileMap, TileType};
+
+const VERTEX_BUFFER_TARGET: u32 = 34962;
+const INDEX_BUFFER_TARGET: u32 = 34963;
+const FLOAT_COMPONENT: u32 = 5126;
+const UNSIGNED_INT_COMPONENT: u32 = 5125;
+
+#[derive(Clone)]
+pub struct TextureFileDescriptor {
+    pub source_path: PathBuf,
+}
+
+#[derive(Clone)]
+pub struct TextureExportDescriptor {
+    pub tile_type: TileType,
+    pub identifier: String,
+    pub diffuse: TextureFileDescriptor,
+    pub normal: Option<TextureFileDescriptor>,
+    pub roughness: Option<TextureFileDescriptor>,
+}
+
+#[derive(Serialize)]
+struct MetadataTextureEntry {
+    id: String,
+    diffuse: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    normal: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    roughness: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ExportMetadata {
+    name: String,
+    width: u32,
+    height: u32,
+    tile_size: f32,
+    textures: Vec<MetadataTextureEntry>,
+    splatmap: String,
+    mesh: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tilemap: Option<String>,
+}
+
+pub fn collect_texture_descriptors(
+    map: &TileMap,
+    registry: &TerrainTextureRegistry,
+) -> Result<Vec<TextureExportDescriptor>> {
+    use std::collections::HashSet;
+
+    let mut used: HashSet<TileType> = HashSet::new();
+    for tile in &map.tiles {
+        used.insert(tile.tile_type);
+    }
+
+    let mut descriptors = Vec::new();
+    for tile_type in TileType::ALL {
+        if !used.contains(&tile_type) {
+            continue;
+        }
+
+        let entry = registry
+            .get(tile_type)
+            .ok_or_else(|| anyhow!("No terrain texture registered for {tile_type:?}"))?;
+
+        let diffuse = TextureFileDescriptor {
+            source_path: resolve_asset_path(&entry.diffuse_path)?,
+        };
+
+        let normal = match &entry.normal_path {
+            Some(path) => Some(TextureFileDescriptor {
+                source_path: resolve_asset_path(path)?,
+            }),
+            None => None,
+        };
+
+        let roughness = match &entry.roughness_path {
+            Some(path) => Some(TextureFileDescriptor {
+                source_path: resolve_asset_path(path)?,
+            }),
+            None => None,
+        };
+
+        descriptors.push(TextureExportDescriptor {
+            tile_type,
+            identifier: tile_type.identifier().to_string(),
+            diffuse,
+            normal,
+            roughness,
+        });
+    }
+
+    Ok(descriptors)
+}
+
+pub fn export_package(
+    output_path: &Path,
+    map: TileMap,
+    map_name: String,
+    textures: Vec<TextureExportDescriptor>,
+) -> Result<()> {
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create export directory {}", parent.display())
+            })?;
+        }
+    }
+
+    let mesh = terrain::build_combined_mesh(&map);
+    let mesh_bytes = mesh_to_glb(&mesh)?;
+
+    let splat_image = splatmap::create(&map);
+    let splat_png = encode_splatmap_png(&splat_image)?;
+
+    let tilemap_json = serde_json::to_vec_pretty(&map)?;
+
+    let (metadata, texture_files) = build_metadata_and_files(&textures)?;
+    let metadata = ExportMetadata {
+        name: map_name,
+        width: map.width,
+        height: map.height,
+        tile_size: TILE_SIZE,
+        textures: metadata,
+        splatmap: "splatmap.png".to_string(),
+        mesh: "mesh.glb".to_string(),
+        tilemap: Some("tilemap.json".to_string()),
+    };
+    let metadata_json = serde_json::to_vec_pretty(&metadata)?;
+
+    let file = File::create(output_path)
+        .with_context(|| format!("Failed to create export file {}", output_path.display()))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = FileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("tilemap.json", options)?;
+    zip.write_all(&tilemap_json)?;
+
+    zip.start_file("mesh.glb", options)?;
+    zip.write_all(&mesh_bytes)?;
+
+    zip.start_file("splatmap.png", options)?;
+    zip.write_all(&splat_png)?;
+
+    zip.start_file("metadata.json", options)?;
+    zip.write_all(&metadata_json)?;
+
+    if !texture_files.is_empty() {
+        zip.add_directory("textures/", options)?;
+    }
+
+    for (path, bytes) in texture_files {
+        zip.start_file(path, options)?;
+        zip.write_all(&bytes)?;
+    }
+
+    zip.finish()?;
+    Ok(())
+}
+
+fn build_metadata_and_files(
+    textures: &[TextureExportDescriptor],
+) -> Result<(Vec<MetadataTextureEntry>, Vec<(String, Vec<u8>)>)> {
+    let mut metadata = Vec::new();
+    let mut files = Vec::new();
+
+    for descriptor in textures {
+        ensure!(
+            descriptor
+                .identifier
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+            "Texture identifier contains unsupported characters"
+        );
+
+        let diffuse_path = texture_target_path(
+            &descriptor.identifier,
+            "diffuse",
+            &descriptor.diffuse.source_path,
+        );
+        let diffuse_bytes = std::fs::read(&descriptor.diffuse.source_path).with_context(|| {
+            format!(
+                "Failed to read diffuse texture for {} from {}",
+                descriptor.identifier,
+                descriptor.diffuse.source_path.display()
+            )
+        })?;
+        files.push((diffuse_path.clone(), diffuse_bytes));
+
+        let mut entry = MetadataTextureEntry {
+            id: descriptor.identifier.clone(),
+            diffuse: diffuse_path,
+            normal: None,
+            roughness: None,
+        };
+
+        if let Some(normal) = &descriptor.normal {
+            let normal_path =
+                texture_target_path(&descriptor.identifier, "normal", &normal.source_path);
+            let normal_bytes = std::fs::read(&normal.source_path).with_context(|| {
+                format!(
+                    "Failed to read normal texture for {} from {}",
+                    descriptor.identifier,
+                    normal.source_path.display()
+                )
+            })?;
+            files.push((normal_path.clone(), normal_bytes));
+            entry.normal = Some(normal_path);
+        }
+
+        if let Some(roughness) = &descriptor.roughness {
+            let roughness_path =
+                texture_target_path(&descriptor.identifier, "roughness", &roughness.source_path);
+            let roughness_bytes = std::fs::read(&roughness.source_path).with_context(|| {
+                format!(
+                    "Failed to read roughness texture for {} from {}",
+                    descriptor.identifier,
+                    roughness.source_path.display()
+                )
+            })?;
+            files.push((roughness_path.clone(), roughness_bytes));
+            entry.roughness = Some(roughness_path);
+        }
+
+        metadata.push(entry);
+    }
+
+    Ok((metadata, files))
+}
+
+fn texture_target_path(id: &str, kind: &str, source: &Path) -> String {
+    let mut file_name = format!("{}_{}", id, kind);
+    if let Some(ext) = source
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .filter(|s| !s.is_empty())
+    {
+        file_name.push('.');
+        file_name.push_str(ext);
+    }
+    format!("textures/{file_name}")
+}
+
+fn resolve_asset_path(path: &str) -> Result<PathBuf> {
+    let raw_path = Path::new(path);
+    let resolved = if raw_path.is_absolute() {
+        raw_path.to_path_buf()
+    } else {
+        Path::new("assets").join(raw_path)
+    };
+
+    if !resolved.exists() {
+        bail!("Asset path not found: {}", resolved.display());
+    }
+
+    Ok(resolved)
+}
+
+fn encode_splatmap_png(image: &Image) -> Result<Vec<u8>> {
+    ensure!(
+        image.texture_descriptor.format == bevy::render::render_resource::TextureFormat::Rgba8Unorm,
+        "Splatmap must be RGBA8 format for export"
+    );
+
+    let width = image.texture_descriptor.size.width;
+    let height = image.texture_descriptor.size.height;
+    let mut buffer = Vec::new();
+    {
+        let mut encoder = PngEncoder::new(&mut buffer);
+        encoder.encode(&image.data, width, height, ColorType::Rgba8)?;
+    }
+    Ok(buffer)
+}
+
+fn mesh_to_glb(mesh: &Mesh) -> Result<Vec<u8>> {
+    let positions = extract_vec3(mesh, Mesh::ATTRIBUTE_POSITION, "POSITION")?;
+    let normals = extract_vec3(mesh, Mesh::ATTRIBUTE_NORMAL, "NORMAL")?;
+    let texcoords = extract_vec2(mesh, Mesh::ATTRIBUTE_UV_0, "TEXCOORD_0")?;
+    let texcoords1 = extract_optional_vec2(mesh, Mesh::ATTRIBUTE_UV_1)?;
+    let colors = extract_optional_vec4(mesh, Mesh::ATTRIBUTE_COLOR)?;
+    let indices = extract_indices(mesh)?;
+
+    ensure!(
+        positions.len() == normals.len(),
+        "Mesh export requires matching position and normal counts"
+    );
+    ensure!(
+        positions.len() == texcoords.len(),
+        "Mesh export requires matching position and UV counts"
+    );
+    if let Some(ref uv1) = texcoords1 {
+        ensure!(
+            uv1.len() == positions.len(),
+            "Secondary UV set must match vertex count"
+        );
+    }
+    if let Some(ref cols) = colors {
+        ensure!(
+            cols.len() == positions.len(),
+            "Vertex color count must match vertices"
+        );
+    }
+
+    let mut writer = BufferWriter::default();
+    let position_accessor = writer.push_vec3(&positions, true)?;
+    let normal_accessor = writer.push_vec3(&normals, false)?;
+    let tex_accessor = writer.push_vec2(&texcoords)?;
+    let tex1_accessor = texcoords1
+        .as_ref()
+        .map(|uvs| writer.push_vec2(uvs))
+        .transpose()?;
+    let color_accessor = colors
+        .as_ref()
+        .map(|cols| writer.push_vec4(cols))
+        .transpose()?;
+    let index_accessor = writer.push_indices(&indices)?;
+
+    let (mut bin, buffer_views, accessors) = writer.finish();
+
+    let mut attributes = serde_json::Map::new();
+    attributes.insert("POSITION".to_string(), json!(position_accessor));
+    attributes.insert("NORMAL".to_string(), json!(normal_accessor));
+    attributes.insert("TEXCOORD_0".to_string(), json!(tex_accessor));
+    if let Some(accessor) = tex1_accessor {
+        attributes.insert("TEXCOORD_1".to_string(), json!(accessor));
+    }
+    if let Some(accessor) = color_accessor {
+        attributes.insert("COLOR_0".to_string(), json!(accessor));
+    }
+
+    let primitive = json!({
+        "attributes": attributes,
+        "indices": index_accessor,
+        "mode": 4,
+    });
+
+    let root = json!({
+        "asset": {
+            "version": "2.0",
+            "generator": "tilemapedit3d exporter",
+        },
+        "buffers": [{
+            "byteLength": bin.len() as u64,
+            "name": "TerrainBuffer",
+        }],
+        "bufferViews": buffer_views,
+        "accessors": accessors,
+        "meshes": [{
+            "name": "Terrain",
+            "primitives": [primitive],
+        }],
+        "nodes": [{
+            "mesh": 0,
+            "name": "Terrain",
+        }],
+        "scenes": [{
+            "nodes": [0],
+        }],
+        "scene": 0,
+    });
+
+    let mut json_bytes = serde_json::to_vec(&root)?;
+    pad_to_four(&mut json_bytes, b' ');
+    pad_to_four(&mut bin, 0);
+
+    let total_length = 12 + 8 + json_bytes.len() + 8 + bin.len();
+    let mut glb = Vec::with_capacity(total_length);
+    glb.extend_from_slice(&0x46546C67u32.to_le_bytes());
+    glb.extend_from_slice(&2u32.to_le_bytes());
+    glb.extend_from_slice(&(total_length as u32).to_le_bytes());
+
+    glb.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
+    glb.extend_from_slice(&0x4E4F534Au32.to_le_bytes());
+    glb.extend_from_slice(&json_bytes);
+
+    glb.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+    glb.extend_from_slice(&0x004E4942u32.to_le_bytes());
+    glb.extend_from_slice(&bin);
+
+    Ok(glb)
+}
+
+fn pad_to_four(buffer: &mut Vec<u8>, pad: u8) {
+    while buffer.len() % 4 != 0 {
+        buffer.push(pad);
+    }
+}
+
+fn extract_vec3(
+    mesh: &Mesh,
+    attribute: bevy::render::mesh::MeshVertexAttribute,
+    name: &str,
+) -> Result<Vec<[f32; 3]>> {
+    let values = mesh
+        .attribute(attribute)
+        .ok_or_else(|| anyhow!("Mesh missing {name} attribute"))?;
+    match values {
+        VertexAttributeValues::Float32x3(data) => Ok(data.clone()),
+        _ => bail!("Mesh attribute {name} has unsupported format"),
+    }
+}
+
+fn extract_vec2(
+    mesh: &Mesh,
+    attribute: bevy::render::mesh::MeshVertexAttribute,
+    name: &str,
+) -> Result<Vec<[f32; 2]>> {
+    let values = mesh
+        .attribute(attribute)
+        .ok_or_else(|| anyhow!("Mesh missing {name} attribute"))?;
+    match values {
+        VertexAttributeValues::Float32x2(data) => Ok(data.clone()),
+        _ => bail!("Mesh attribute {name} has unsupported format"),
+    }
+}
+
+fn extract_optional_vec2(
+    mesh: &Mesh,
+    attribute: bevy::render::mesh::MeshVertexAttribute,
+) -> Result<Option<Vec<[f32; 2]>>> {
+    let Some(values) = mesh.attribute(attribute) else {
+        return Ok(None);
+    };
+    match values {
+        VertexAttributeValues::Float32x2(data) => Ok(Some(data.clone())),
+        _ => bail!("Mesh attribute has unsupported format"),
+    }
+}
+
+fn extract_optional_vec4(
+    mesh: &Mesh,
+    attribute: bevy::render::mesh::MeshVertexAttribute,
+) -> Result<Option<Vec<[f32; 4]>>> {
+    let Some(values) = mesh.attribute(attribute) else {
+        return Ok(None);
+    };
+    match values {
+        VertexAttributeValues::Float32x4(data) => Ok(Some(data.clone())),
+        _ => bail!("Mesh attribute has unsupported format"),
+    }
+}
+
+fn extract_indices(mesh: &Mesh) -> Result<Vec<u32>> {
+    let indices = mesh
+        .indices()
+        .ok_or_else(|| anyhow!("Mesh is missing triangle indices"))?;
+    match indices {
+        Indices::U16(data) => Ok(data.iter().map(|&value| value as u32).collect()),
+        Indices::U32(data) => Ok(data.clone()),
+    }
+}
+
+#[derive(Default)]
+struct BufferWriter {
+    data: Vec<u8>,
+    buffer_views: Vec<serde_json::Value>,
+    accessors: Vec<serde_json::Value>,
+}
+
+impl BufferWriter {
+    fn align(&mut self) {
+        while self.data.len() % 4 != 0 {
+            self.data.push(0);
+        }
+    }
+
+    fn push_vec3(&mut self, values: &[[f32; 3]], include_bounds: bool) -> Result<usize> {
+        ensure!(!values.is_empty(), "Vector attribute cannot be empty");
+        self.align();
+        let byte_offset = self.data.len();
+        let bytes = bytemuck::cast_slice(values);
+        self.data.extend_from_slice(bytes);
+        let byte_length = bytes.len();
+        let view_index = self.buffer_views.len();
+        let mut view = serde_json::Map::new();
+        view.insert("buffer".into(), json!(0));
+        if byte_offset != 0 {
+            view.insert("byteOffset".into(), json!(byte_offset as u64));
+        }
+        view.insert("byteLength".into(), json!(byte_length as u64));
+        view.insert("target".into(), json!(VERTEX_BUFFER_TARGET));
+        self.buffer_views.push(serde_json::Value::Object(view));
+
+        let accessor_index = self.accessors.len();
+        let mut accessor = serde_json::Map::new();
+        accessor.insert("bufferView".into(), json!(view_index));
+        accessor.insert("componentType".into(), json!(FLOAT_COMPONENT));
+        accessor.insert("count".into(), json!(values.len() as u64));
+        accessor.insert("type".into(), serde_json::Value::String("VEC3".into()));
+        if include_bounds {
+            let (min, max) = bounds_vec3(values);
+            accessor.insert("min".into(), json!(min));
+            accessor.insert("max".into(), json!(max));
+        }
+        self.accessors.push(serde_json::Value::Object(accessor));
+        Ok(accessor_index)
+    }
+
+    fn push_vec2(&mut self, values: &[[f32; 2]]) -> Result<usize> {
+        ensure!(!values.is_empty(), "Vector attribute cannot be empty");
+        self.align();
+        let byte_offset = self.data.len();
+        let bytes = bytemuck::cast_slice(values);
+        self.data.extend_from_slice(bytes);
+        let byte_length = bytes.len();
+        let view_index = self.buffer_views.len();
+        let mut view = serde_json::Map::new();
+        view.insert("buffer".into(), json!(0));
+        if byte_offset != 0 {
+            view.insert("byteOffset".into(), json!(byte_offset as u64));
+        }
+        view.insert("byteLength".into(), json!(byte_length as u64));
+        view.insert("target".into(), json!(VERTEX_BUFFER_TARGET));
+        self.buffer_views.push(serde_json::Value::Object(view));
+
+        let accessor_index = self.accessors.len();
+        let mut accessor = serde_json::Map::new();
+        accessor.insert("bufferView".into(), json!(view_index));
+        accessor.insert("componentType".into(), json!(FLOAT_COMPONENT));
+        accessor.insert("count".into(), json!(values.len() as u64));
+        accessor.insert("type".into(), serde_json::Value::String("VEC2".into()));
+        self.accessors.push(serde_json::Value::Object(accessor));
+        Ok(accessor_index)
+    }
+
+    fn push_vec4(&mut self, values: &[[f32; 4]]) -> Result<usize> {
+        ensure!(!values.is_empty(), "Vector attribute cannot be empty");
+        self.align();
+        let byte_offset = self.data.len();
+        let bytes = bytemuck::cast_slice(values);
+        self.data.extend_from_slice(bytes);
+        let byte_length = bytes.len();
+        let view_index = self.buffer_views.len();
+        let mut view = serde_json::Map::new();
+        view.insert("buffer".into(), json!(0));
+        if byte_offset != 0 {
+            view.insert("byteOffset".into(), json!(byte_offset as u64));
+        }
+        view.insert("byteLength".into(), json!(byte_length as u64));
+        view.insert("target".into(), json!(VERTEX_BUFFER_TARGET));
+        self.buffer_views.push(serde_json::Value::Object(view));
+
+        let accessor_index = self.accessors.len();
+        let mut accessor = serde_json::Map::new();
+        accessor.insert("bufferView".into(), json!(view_index));
+        accessor.insert("componentType".into(), json!(FLOAT_COMPONENT));
+        accessor.insert("count".into(), json!(values.len() as u64));
+        accessor.insert("type".into(), serde_json::Value::String("VEC4".into()));
+        self.accessors.push(serde_json::Value::Object(accessor));
+        Ok(accessor_index)
+    }
+
+    fn push_indices(&mut self, values: &[u32]) -> Result<usize> {
+        ensure!(!values.is_empty(), "Index buffer cannot be empty");
+        self.align();
+        let byte_offset = self.data.len();
+        let bytes = bytemuck::cast_slice(values);
+        self.data.extend_from_slice(bytes);
+        let byte_length = bytes.len();
+        let view_index = self.buffer_views.len();
+        let mut view = serde_json::Map::new();
+        view.insert("buffer".into(), json!(0));
+        if byte_offset != 0 {
+            view.insert("byteOffset".into(), json!(byte_offset as u64));
+        }
+        view.insert("byteLength".into(), json!(byte_length as u64));
+        view.insert("target".into(), json!(INDEX_BUFFER_TARGET));
+        self.buffer_views.push(serde_json::Value::Object(view));
+
+        let accessor_index = self.accessors.len();
+        let mut accessor = serde_json::Map::new();
+        accessor.insert("bufferView".into(), json!(view_index));
+        accessor.insert("componentType".into(), json!(UNSIGNED_INT_COMPONENT));
+        accessor.insert("count".into(), json!(values.len() as u64));
+        accessor.insert("type".into(), serde_json::Value::String("SCALAR".into()));
+        self.accessors.push(serde_json::Value::Object(accessor));
+        Ok(accessor_index)
+    }
+
+    fn finish(self) -> (Vec<u8>, Vec<serde_json::Value>, Vec<serde_json::Value>) {
+        (self.data, self.buffer_views, self.accessors)
+    }
+}
+
+fn bounds_vec3(values: &[[f32; 3]]) -> ([f32; 3], [f32; 3]) {
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for value in values {
+        for i in 0..3 {
+            min[i] = min[i].min(value[i]);
+            max[i] = max[i].max(value[i]);
+        }
+    }
+    (min, max)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod camera;
 mod controls;
+mod debug;
 mod editor;
+mod export;
 mod grid_visual;
 mod io;
 mod runtime;
@@ -8,8 +10,9 @@ mod terrain;
 mod texture;
 mod types;
 mod ui;
-mod debug;
 
+use crate::debug::asset::image_inspector::ImageInspectorPlugin;
+use crate::texture::material;
 use bevy::prelude::*;
 use bevy_egui::EguiPlugin;
 use camera::CameraPlugin;
@@ -18,8 +21,6 @@ use editor::EditorPlugin;
 use runtime::RuntimePlugin;
 use texture::TexturePlugin;
 use ui::UiPlugin;
-use crate::debug::asset::image_inspector::ImageInspectorPlugin;
-use crate::texture::material;
 
 fn main() {
     App::new()
@@ -35,13 +36,11 @@ fn main() {
             EditorPlugin,
             RuntimePlugin,
             UiPlugin,
-            ImageInspectorPlugin
+            ImageInspectorPlugin,
         ))
         .add_systems(Startup, setup_light)
         .add_systems(Update, grid_visual::draw_grid)
         // .add_systems(Update, material::fix_roughness_images_on_load)
-
-
         .run();
 }
 

--- a/src/texture/registry.rs
+++ b/src/texture/registry.rs
@@ -17,6 +17,10 @@ pub struct TerrainTextureEntry {
     pub normal: Option<Handle<Image>>,
     pub roughness: Option<Handle<Image>>,
     pub dispersion: Option<Handle<Image>>,
+    pub diffuse_path: String,
+    pub normal_path: Option<String>,
+    pub roughness_path: Option<String>,
+    pub dispersion_path: Option<String>,
 }
 
 #[derive(Resource, Default)]
@@ -76,6 +80,10 @@ impl TerrainTextureRegistry {
             normal: normal_handle,
             roughness: roughness_handle,
             dispersion: dispersion_handle,
+            diffuse_path: base_color.to_string(),
+            normal_path: normal.map(|s| s.to_string()),
+            roughness_path: roughness.map(|s| s.to_string()),
+            dispersion_path: dispersion.map(|s| s.to_string()),
         });
 
         material

--- a/src/types.rs
+++ b/src/types.rs
@@ -66,6 +66,15 @@ impl TileType {
             TileType::Rock => 3,
         }
     }
+
+    pub fn identifier(self) -> &'static str {
+        match self {
+            TileType::Grass => "grass",
+            TileType::Dirt => "dirt",
+            TileType::Cliff => "cliff",
+            TileType::Rock => "rock",
+        }
+    }
 }
 
 impl Default for TileType {
@@ -85,7 +94,7 @@ pub struct Tile {
     pub ramp_direction: Option<RampDirection>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Encode, Decode)]
+#[derive(Serialize, Deserialize, Debug, Encode, Decode, Clone)]
 pub struct TileMap {
     pub width: u32,
     pub height: u32,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,12 @@
-use crate::editor::EditorTool;
+use crate::editor::{EditorTool, ExportStatus};
+use crate::export;
 use crate::io::{load_map, save_map};
 use crate::types::*;
 use bevy::prelude::*;
-use bevy::tasks::{block_on, IoTaskPool};
-use bevy_egui::{egui, EguiContexts};
+use bevy::tasks::{IoTaskPool, block_on};
+use bevy_egui::{EguiContexts, egui};
 use rfd::AsyncFileDialog;
+use std::path::{Path, PathBuf};
 
 use crate::texture::registry::TerrainTextureRegistry;
 
@@ -74,6 +76,30 @@ fn ui_panel(
                 }
 
                 state.save_dialog_task = Some(IoTaskPool::get().spawn(async move {
+                    dialog
+                        .save_file()
+                        .await
+                        .map(|file| file.path().to_path_buf())
+                }));
+            }
+            if ui.button("Export…").clicked()
+                && state.export_dialog_task.is_none()
+                && state.export_task.is_none()
+            {
+                let mut dialog = AsyncFileDialog::new().set_title("Export Map");
+                dialog = dialog.add_filter("Tile Map Package", &["tmemapdata"]);
+                if let Some(path) = state.current_file_path.as_ref() {
+                    if let Some(parent) = path.parent() {
+                        dialog = dialog.set_directory(parent);
+                    }
+                    if let Some(stem) = path.file_stem().and_then(|name| name.to_str()) {
+                        dialog = dialog.set_file_name(format!("{stem}.tmemapdata"));
+                    }
+                } else {
+                    dialog = dialog.set_file_name("map.tmemapdata");
+                }
+
+                state.export_dialog_task = Some(IoTaskPool::get().spawn(async move {
                     dialog
                         .save_file()
                         .await
@@ -160,6 +186,18 @@ fn ui_panel(
             ui.separator();
             ui.label(format!("Current map: {}", path.display()));
         }
+
+        if let Some(status) = state.last_export_status.as_ref() {
+            ui.separator();
+            match status {
+                ExportStatus::Success(message) => {
+                    ui.colored_label(egui::Color32::from_rgb(56, 142, 60), message);
+                }
+                ExportStatus::Failure(message) => {
+                    ui.colored_label(egui::Color32::from_rgb(198, 40, 40), message);
+                }
+            }
+        }
     });
 
     if let Some(task) = state.save_dialog_task.as_mut() {
@@ -169,6 +207,54 @@ fn ui_panel(
                     eprintln!("Failed to save map: {err:?}");
                 } else {
                     state.current_file_path = Some(path);
+                }
+            }
+        }
+    }
+
+    if let Some(task) = state.export_dialog_task.as_mut() {
+        if task.is_finished() {
+            if let Some(path) = block_on(state.export_dialog_task.take().unwrap()) {
+                let export_path = ensure_extension(path, "tmemapdata");
+                match export::collect_texture_descriptors(&state.map, textures.as_ref()) {
+                    Ok(descriptors) => {
+                        let map_clone = state.map.clone();
+                        let export_name = infer_export_name(&state, &export_path);
+                        let export_path_clone = export_path.clone();
+                        state.last_export_status = None;
+                        state.export_task = Some(IoTaskPool::get().spawn(async move {
+                            export::export_package(
+                                &export_path_clone,
+                                map_clone,
+                                export_name,
+                                descriptors,
+                            )
+                            .map(|_| export_path_clone)
+                        }));
+                    }
+                    Err(err) => {
+                        eprintln!("Failed to gather textures for export: {err:?}");
+                        state.last_export_status =
+                            Some(ExportStatus::Failure(format!("Export failed: {err}")));
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(task) = state.export_task.as_mut() {
+        if task.is_finished() {
+            match block_on(state.export_task.take().unwrap()) {
+                Ok(path) => {
+                    state.last_export_status = Some(ExportStatus::Success(format!(
+                        "Exported map to {}",
+                        path.display()
+                    )));
+                }
+                Err(err) => {
+                    eprintln!("Failed to export map: {err:?}");
+                    state.last_export_status =
+                        Some(ExportStatus::Failure(format!("Export failed: {err}")));
                 }
             }
         }
@@ -196,4 +282,30 @@ struct PaletteItem {
     tile_type: TileType,
     name: String,
     texture: egui::TextureId,
+}
+
+fn ensure_extension(mut path: PathBuf, extension: &str) -> PathBuf {
+    let needs_extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| !ext.eq_ignore_ascii_case(extension))
+        .unwrap_or(true);
+    if needs_extension {
+        path.set_extension(extension);
+    }
+    path
+}
+
+fn infer_export_name(state: &crate::editor::EditorState, export_path: &Path) -> String {
+    if let Some(path) = state.current_file_path.as_ref() {
+        if let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) {
+            return stem.to_string();
+        }
+    }
+
+    export_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .map(|stem| stem.to_string())
+        .unwrap_or_else(|| "Tile Map".to_string())
 }


### PR DESCRIPTION
## Summary
- add an export module that packages the tilemap, mesh, splatmap, textures, and metadata into a `.tmemapdata` archive
- keep track of terrain texture source paths and tile identifiers so exports only include the assets they need
- add an Export workflow in the UI that runs asynchronously and reports success or failure to the user

## Testing
- cargo fmt
- cargo check *(fails: missing system library `alsa` required by `alsa-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68e33bbe87988332b7707e52032b68a7